### PR TITLE
feat: add dark mode with system tracking and manual override

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -106,7 +106,7 @@ Do not introduce box-shadow, ring-shadow, or elevation utilities.
 Primary breakpoint: **md (768px)**. Secondary: **sm (640px)** used in the photography gallery grid.
 
 Below md: hamburger menu, 24px horizontal padding, vertical nav at 1.5rem light weight.
-Above md: horizontal nav bar, 72px horizontal padding, social links visible in header.
+Above md: horizontal nav bar, 72px horizontal padding, theme toggle in nav. Social links visible in header above lg (hidden at md–lg for breathing room; always available in footer).
 
 Grid layouts: homepage uses `grid-cols-3 max-md:grid-cols-1`, portfolio index uses `grid-cols-2 max-md:grid-cols-1`, photography gallery uses `grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1`.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,7 +6,7 @@ Prometheas.com is the personal website of John Lianoglou — a portfolio, blog, 
 
 ## Visual Theme & Atmosphere
 
-The site is serene, precise, and architecturally structured. White canvas dominates. Slate grays establish atmosphere and tonal depth. Red appears only as punctuation — interactive elements and accent marks. Hierarchy is communicated through hairline borders and typographic weight, never shadows or elevation. Every element earns its place; ornamentation is purposeful, never decorative.
+The site is serene, precise, and architecturally structured. White canvas dominates. Zinc grays establish atmosphere and tonal depth. Red appears only as punctuation — interactive elements and accent marks. Hierarchy is communicated through hairline borders and typographic weight, never shadows or elevation. Every element earns its place; ornamentation is purposeful, never decorative.
 
 The design is **not** brutalist, maximalist, corporate SaaS, or "generic tech startup." It belongs to a person, not a product.
 
@@ -16,14 +16,14 @@ The design is **not** brutalist, maximalist, corporate SaaS, or "generic tech st
 |-------|-----|-------------|------|-------|
 | Red | `#C23B22` | `--color-red` | Primary accent | Links, hover states, accent dots. As background: only for interactive overlays (mobile nav) and CTA buttons. Never for content regions. |
 | Red Hover | `#A83019` | `--color-red-hover` | Accent hover | Darkened red for interactive feedback. Pairs only with red base. |
-| Slate 900 | `#0f172a` | `--color-slate-900` | Primary text | Headings, body text on light backgrounds. |
-| Slate 700 | `#334155` | `--color-slate-700` | Secondary text | Nav labels, subheadings, emphasized metadata. |
-| Slate 600 | `#475569` | `--color-slate-600` | Tertiary text | Descriptions, supporting copy, blockquotes. |
-| Slate 500 | `#64748b` | `--color-slate-500` | Muted text | Captions, timestamps, disabled states. AA for large text only. |
-| Slate 300 | `#cbd5e1` | `--color-slate-300` | Borders | Visible hairline rules and dividers. |
-| Slate 200 | `#e2e8f0` | `--color-slate-200` | Subtle borders | Secondary borders, code block outlines. |
-| Slate 100 | `#f1f5f9` | `--color-slate-100` | Surface | Alternate backgrounds, subtle differentiation. Not for code blocks (use slate-50). |
-| Slate 50 | `#f8fafc` | `--color-slate-50` | Canvas tint | Near-white background when pure white is too stark. |
+| Zinc 900 | `#18181b` | `--color-zinc-900` | Primary text | Headings, body text on light backgrounds. |
+| Zinc 700 | `#3f3f46` | `--color-zinc-700` | Secondary text | Nav labels, subheadings, emphasized metadata. |
+| Zinc 600 | `#52525b` | `--color-zinc-600` | Tertiary text | Descriptions, supporting copy, blockquotes. |
+| Zinc 500 | `#71717a` | `--color-zinc-500` | Muted text | Captions, timestamps, disabled states. AA for large text only. |
+| Zinc 300 | `#d4d4d8` | `--color-zinc-300` | Borders | Visible hairline rules and dividers. |
+| Zinc 200 | `#e4e4e7` | `--color-zinc-200` | Subtle borders | Secondary borders, code block outlines. |
+| Zinc 100 | `#f4f4f5` | `--color-zinc-100` | Surface | Alternate backgrounds, subtle differentiation. Not for code blocks (use zinc-50). |
+| Zinc 50 | `#fafafa` | `--color-zinc-50` | Canvas tint | Near-white background when pure white is too stark. |
 
 ## Typography Rules
 
@@ -64,23 +64,23 @@ Horizontal padding: 72px (desktop) / 24px (mobile), switching at `md` (768px).
 
 **Links:** `text-red no-underline`, hover: `opacity-70` (content links) or `text-red transition-colors` (nav links).
 
-**Header:** Flex row, gradient bottom rule (red 60px → slate-100). Logo: "Prometheas" + red bold dot + "com."
+**Header:** Flex row, gradient bottom rule (red 60px → zinc-100). Logo: "Prometheas" + red bold dot + "com."
 
 **Mobile Nav:** Fixed red overlay sliding from top (content-driven height, not full-viewport). Hamburger morphs to X. Nav links stagger in (70ms per item). White text on red background.
 
-**Footer:** Centered, hairline top border (slate-100). Social icons + copyright.
+**Footer:** Centered, hairline top border (zinc-100). Social icons + copyright.
 
-**Post Excerpt:** Article with bottom border (slate-100). Meta row (date + category) above title link. Excerpt below.
+**Post Excerpt:** Article with bottom border (zinc-100). Meta row (date + category) above title link. Excerpt below.
 
-**Blockquotes:** Red left border, slate-600 text.
+**Blockquotes:** Red left border, zinc-600 text.
 
-**Code blocks:** Pre with slate-50 background, 1px slate-200 border. Inline code at 0.875em.
+**Code blocks:** Pre with zinc-50 background, 1px zinc-200 border. Inline code at 0.875em.
 
 ## Depth & Elevation
 
 This site intentionally uses **no shadows**. Visual hierarchy is established through:
-- Hairline borders (1px, slate-100 or slate-200)
-- Gradient rules (red accent fading to slate)
+- Hairline borders (1px, zinc-100 or zinc-200)
+- Gradient rules (red accent fading to zinc)
 - Typographic weight and color contrast
 - Whitespace
 
@@ -99,7 +99,7 @@ Do not introduce box-shadow, ring-shadow, or elevation utilities.
 - **DON'T** use more than two font weights in a single component unless structurally justified (the Header uses three: 450 for nav, 600 for logo text, 700 for the logo dot)
 - **DON'T** apply uppercase to body text, titles, or excerpts
 - **DON'T** add decorative elements without clear functional purpose
-- **DON'T** use warm grays — the palette is exclusively cool slate
+- **DON'T** use warm grays — the palette is exclusively zinc
 
 ## Responsive Behavior
 

--- a/docs/design/colors.md
+++ b/docs/design/colors.md
@@ -1,6 +1,6 @@
 # Color System
 
-Color on Prometheas.com serves two roles: slate grays establish atmosphere and hierarchy, while red delivers punctuation and interactivity. The palette is intentionally narrow -- a disciplined set of tokens that prevents color drift and keeps the site visually coherent.
+Color on Prometheas.com serves two roles: zinc grays establish atmosphere and hierarchy, while red delivers punctuation and interactivity. The palette is intentionally narrow -- a disciplined set of tokens that prevents color drift and keeps the site visually coherent.
 
 ---
 
@@ -10,14 +10,14 @@ Color on Prometheas.com serves two roles: slate grays establish atmosphere and h
 |------------|-----|--------------|---------------|------------|
 | Red | `#C23B22` | `--color-red` | Primary accent | Interactive elements -- links, hover states, accent dots, active indicators. As background: permitted for interactive overlays (mobile nav) and CTA buttons. Never as background for content regions, cards, or sections. |
 | Red Hover | `#A83019` | `--color-red-hover` | Accent hover state | Darkened red for hover/active feedback on interactive elements. Pair exclusively with `--color-red` base states. |
-| Slate 900 | `#0f172a` | `--color-slate-900` | Primary text | Headings and body text on light backgrounds. The darkest neutral in the system. |
-| Slate 700 | `#334155` | `--color-slate-700` | Secondary text | Subheadings, emphasized metadata, navigation labels. Slightly softer than 900 for secondary hierarchy. |
-| Slate 600 | `#475569` | `--color-slate-600` | Tertiary text | Descriptions, supporting copy, timestamps. A workhorse for text that should be present but not dominant. |
-| Slate 500 | `#64748b` | `--color-slate-500` | Muted text | Placeholders, disabled states, captions, footnotes. The lightest text token safe for extended reading. |
-| Slate 300 | `#cbd5e1` | `--color-slate-300` | Borders | Hairline rules, dividers, input borders. Visible on white backgrounds without being heavy. |
-| Slate 200 | `#e2e8f0` | `--color-slate-200` | Subtle borders | Secondary borders, table rules, separator lines. Lighter than 300 for contexts where borders should nearly disappear. |
-| Slate 100 | `#f1f5f9` | `--color-slate-100` | Surface | Alternate row backgrounds, subtle surface differentiation against white. |
-| Slate 50 | `#f8fafc` | `--color-slate-50` | Canvas tint / Code bg | Code block backgrounds (`<pre>`), page-level background tint when pure white is too stark. |
+| Zinc 900 | `#18181b` | `--color-zinc-900` | Primary text | Headings and body text on light backgrounds. The darkest neutral in the system. |
+| Zinc 700 | `#3f3f46` | `--color-zinc-700` | Secondary text | Subheadings, emphasized metadata, navigation labels. Slightly softer than 900 for secondary hierarchy. |
+| Zinc 600 | `#52525b` | `--color-zinc-600` | Tertiary text | Descriptions, supporting copy, timestamps. A workhorse for text that should be present but not dominant. |
+| Zinc 500 | `#71717a` | `--color-zinc-500` | Muted text | Placeholders, disabled states, captions, footnotes. The lightest text token safe for extended reading. |
+| Zinc 300 | `#d4d4d8` | `--color-zinc-300` | Borders | Hairline rules, dividers, input borders. Visible on white backgrounds without being heavy. |
+| Zinc 200 | `#e4e4e7` | `--color-zinc-200` | Subtle borders | Secondary borders, table rules, separator lines. Lighter than 300 for contexts where borders should nearly disappear. |
+| Zinc 100 | `#f4f4f5` | `--color-zinc-100` | Surface | Alternate row backgrounds, subtle surface differentiation against white. |
+| Zinc 50 | `#fafafa` | `--color-zinc-50` | Canvas tint / Code bg | Code block backgrounds (`<pre>`), page-level background tint when pure white is too stark. |
 
 ---
 
@@ -26,17 +26,17 @@ Color on Prometheas.com serves two roles: slate grays establish atmosphere and h
 **Red tokens (`--color-red`, `--color-red-hover`)**
 Red is reserved for elements that invite interaction or demand attention. Links, buttons, the logo dot, navigation hover states, and focus rings. Red backgrounds are permitted in two contexts: interactive overlays (the mobile navigation menu) and CTA buttons (the contact form submit). Red must never fill content areas, appear as a background behind text blocks or cards, or be used decoratively. If red appears, the user should be able to click it or it should be marking something active.
 
-**Dark slates (`--color-slate-900`, `--color-slate-700`)**
-These are text colors. Slate 900 is for primary content -- headings and body paragraphs. Slate 700 is for secondary elements that need to be legible but should not compete with primary text. Do not use these as background colors.
+**Dark zincs (`--color-zinc-900`, `--color-zinc-700`)**
+These are text colors. Zinc 900 is for primary content -- headings and body paragraphs. Zinc 700 is for secondary elements that need to be legible but should not compete with primary text. Do not use these as background colors.
 
-**Mid slates (`--color-slate-600`, `--color-slate-500`)**
-Supporting text tiers. Slate 600 handles descriptions and metadata that accompany primary content. Slate 500 is the floor for readable text -- anything lighter risks failing accessibility thresholds on white backgrounds.
+**Mid zincs (`--color-zinc-600`, `--color-zinc-500`)**
+Supporting text tiers. Zinc 600 handles descriptions and metadata that accompany primary content. Zinc 500 is the floor for readable text -- anything lighter risks failing accessibility thresholds on white backgrounds.
 
-**Light slates (`--color-slate-300`, `--color-slate-200`)**
-Border and rule colors exclusively. These should never be used for text. Slate 300 is the default for visible borders; Slate 200 is for borders that should be felt more than seen.
+**Light zincs (`--color-zinc-300`, `--color-zinc-200`)**
+Border and rule colors exclusively. These should never be used for text. Zinc 300 is the default for visible borders; Zinc 200 is for borders that should be felt more than seen.
 
-**Surface slates (`--color-slate-100`, `--color-slate-50`)**
-Background tints for subtle surface differentiation. Slate 100 provides gentle contrast against white for alternate row backgrounds or card surfaces. Slate 50 is the code block background color and a near-white page tint.
+**Surface zincs (`--color-zinc-100`, `--color-zinc-50`)**
+Background tints for subtle surface differentiation. Zinc 100 provides gentle contrast against white for alternate row backgrounds or card surfaces. Zinc 50 is the code block background color and a near-white page tint.
 
 ---
 
@@ -46,17 +46,55 @@ WCAG 2.1 contrast ratios for key combinations (against white `#FFFFFF`):
 
 | Foreground | Background | Ratio | WCAG AA | WCAG AAA |
 |------------|------------|-------|---------|----------|
-| Slate 900 (`#0f172a`) | White | 17.85:1 | Pass | Pass |
-| Slate 700 (`#334155`) | White | 10.35:1 | Pass | Pass |
-| Slate 600 (`#475569`) | White | 7.58:1 | Pass | Pass |
-| Slate 500 (`#64748b`) | White | 4.76:1 | Pass | Pass (large text) |
+| Zinc 900 (`#18181b`) | White | 17.57:1 | Pass | Pass |
+| Zinc 700 (`#3f3f46`) | White | 9.81:1 | Pass | Pass |
+| Zinc 600 (`#52525b`) | White | 7.22:1 | Pass | Pass |
+| Zinc 500 (`#71717a`) | White | 4.60:1 | Pass | Pass (large text) |
 | Red (`#C23B22`) | White | 5.33:1 | Pass | Pass (large text) |
-| Slate 900 (`#0f172a`) | Slate 100 (`#f1f5f9`) | 16.30:1 | Pass | Pass |
+| Zinc 900 (`#18181b`) | Zinc 100 (`#f4f4f5`) | 16.40:1 | Pass | Pass |
 
-**Key constraints:** Slate 500 and Red pass AA for normal text but fall short of AAA -- they meet AAA only for large text (18px+ or 14px bold). Body copy should use Slate 900, 700, or 600 for full AAA compliance. Red text should be limited to links and interactive labels where the element's role provides additional context beyond color alone.
+**Key constraints:** Zinc 500 and Red pass AA for normal text but fall short of AAA -- they meet AAA only for large text (18px+ or 14px bold). Body copy should use Zinc 900, 700, or 600 for full AAA compliance. Red text should be limited to links and interactive labels where the element's role provides additional context beyond color alone.
+
+---
+
+## Red Scale
+
+The full red scale is available for fine-grained accent control. Brand red (600) and hover red (700) are the primary interactive tokens; the remaining stops are available for tints, tones, and dark mode inversions.
+
+| Step | Hex | Notes |
+|------|-----|-------|
+| 50 | `#fdf3f1` | Lightest tint |
+| 100 | `#fce3de` | |
+| 200 | `#f9cbc2` | |
+| 300 | `#f2a496` | |
+| 400 | `#ea7661` | |
+| 500 | `#df4e34` | |
+| 600 | `#C23B22` | **Brand red** (`--color-red`) |
+| 700 | `#A83019` | **Hover red** (`--color-red-hover`) |
+| 800 | `#812818` | |
+| 900 | `#672418` | |
+| 950 | `#3e1109` | Darkest tone |
 
 ---
 
 ## Dark Mode
 
-Dark mode tokens are not yet defined. This section is reserved for future implementation. When dark mode is introduced, each token above will receive a corresponding dark variant. The inversion strategy should preserve the same semantic roles -- e.g., the darkest text token in light mode maps to the lightest text token in dark mode -- while maintaining equivalent contrast ratios.
+Dark mode is implemented via a `data-theme="dark"` attribute on `<html>`. Each semantic CSS variable is remapped in the dark theme scope. The inversion strategy preserves semantic roles -- the darkest text token in light mode maps to the lightest in dark mode -- while maintaining equivalent contrast ratios against dark backgrounds.
+
+**Semantic variable mappings (dark theme):**
+
+| Semantic Role | Light value | Dark value |
+|---------------|-------------|------------|
+| Primary text | `zinc-900` (`#18181b`) | `zinc-50` (`#fafafa`) |
+| Secondary text | `zinc-700` (`#3f3f46`) | `zinc-300` (`#d4d4d8`) |
+| Tertiary text | `zinc-600` (`#52525b`) | `zinc-400` (`#a1a1aa`) |
+| Muted text | `zinc-500` (`#71717a`) | `zinc-500` (`#71717a`) |
+| Borders | `zinc-300` (`#d4d4d8`) | `zinc-700` (`#3f3f46`) |
+| Subtle borders | `zinc-200` (`#e4e4e7`) | `zinc-800` (`#27272a`) |
+| Surface | `zinc-100` (`#f4f4f5`) | `zinc-800` (`#27272a`) |
+| Canvas tint / Code bg | `zinc-50` (`#fafafa`) | `zinc-950` (`#09090b`) |
+| Page background | `white` (`#ffffff`) | `zinc-900` (`#18181b`) |
+| Brand red | `#C23B22` | `#C23B22` (unchanged) |
+| Red hover | `#A83019` | `#A83019` (unchanged) |
+
+**Note:** `zinc-800` (`#27272a`) and `zinc-950` (`#09090b`) are dark mode tokens. They do not appear in light mode design, but are valid design system values for dark surface and background layers.

--- a/docs/design/colors.md
+++ b/docs/design/colors.md
@@ -79,22 +79,21 @@ The full red scale is available for fine-grained accent control. Brand red (600)
 
 ## Dark Mode
 
-Dark mode is implemented via a `data-theme="dark"` attribute on `<html>`. Each semantic CSS variable is remapped in the dark theme scope. The inversion strategy preserves semantic roles -- the darkest text token in light mode maps to the lightest in dark mode -- while maintaining equivalent contrast ratios against dark backgrounds.
+Dark mode is implemented via a `.dark` class on `<html>`, toggled by a ThemeProvider client component with a blocking inline script for FOUC prevention. Each semantic CSS variable is remapped in the `.dark` scope. The inversion strategy preserves semantic roles — the darkest text token in light mode maps to the lightest in dark mode — while maintaining WCAG AA contrast ratios against dark backgrounds. The accent red shifts two steps lighter for contrast on dark surfaces.
 
-**Semantic variable mappings (dark theme):**
+**Semantic variable mappings:**
 
-| Semantic Role | Light value | Dark value |
-|---------------|-------------|------------|
-| Primary text | `zinc-900` (`#18181b`) | `zinc-50` (`#fafafa`) |
-| Secondary text | `zinc-700` (`#3f3f46`) | `zinc-300` (`#d4d4d8`) |
-| Tertiary text | `zinc-600` (`#52525b`) | `zinc-400` (`#a1a1aa`) |
-| Muted text | `zinc-500` (`#71717a`) | `zinc-500` (`#71717a`) |
-| Borders | `zinc-300` (`#d4d4d8`) | `zinc-700` (`#3f3f46`) |
-| Subtle borders | `zinc-200` (`#e4e4e7`) | `zinc-800` (`#27272a`) |
-| Surface | `zinc-100` (`#f4f4f5`) | `zinc-800` (`#27272a`) |
-| Canvas tint / Code bg | `zinc-50` (`#fafafa`) | `zinc-950` (`#09090b`) |
-| Page background | `white` (`#ffffff`) | `zinc-900` (`#18181b`) |
-| Brand red | `#C23B22` | `#C23B22` (unchanged) |
-| Red hover | `#A83019` | `#A83019` (unchanged) |
+| Token | Light | Dark |
+|-------|-------|------|
+| `--bg-base` | zinc-50 (`#fafafa`) | zinc-900 (`#18181b`) |
+| `--bg-surface` | white (`#ffffff`) | zinc-800 (`#27272a`) |
+| `--bg-muted` | zinc-100 (`#f4f4f5`) | zinc-900 (`#18181b`) |
+| `--text-primary` | zinc-900 (`#18181b`) | zinc-100 (`#f4f4f5`) |
+| `--text-secondary` | zinc-600 (`#52525b`) | zinc-300 (`#d4d4d8`) |
+| `--text-muted` | zinc-500 (`#71717a`) | zinc-400 (`#a1a1aa`) |
+| `--border` | zinc-200 (`#e4e4e7`) | zinc-700 (`#3f3f46`) |
+| `--border-subtle` | zinc-100 (`#f4f4f5`) | zinc-700 (`#3f3f46`) |
+| `--accent` | red-600 (`#C23B22`) | red-400 (`#ea7661`) |
+| `--accent-hover` | red-700 (`#A83019`) | red-500 (`#df4e34`) |
 
 **Note:** `zinc-800` (`#27272a`) and `zinc-950` (`#09090b`) are dark mode tokens. They do not appear in light mode design, but are valid design system values for dark surface and background layers.

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -21,7 +21,7 @@ Prometheas<span className="text-red font-bold">.</span>com
 **Column / card heading circle** — a `<span>` rendered inside an `h2` flex row:
 
 ```tsx
-<h2 className="text-[1.15rem] font-medium text-slate-900 mb-4 flex items-center gap-2.5">
+<h2 className="text-[1.15rem] font-medium text-zinc-900 mb-4 flex items-center gap-2.5">
   <span className="w-2 h-2 border-[1.5px] border-red rounded-full shrink-0" />
   {title}
 </h2>
@@ -33,7 +33,7 @@ Used in: `src/app/page.tsx` (Column component), `src/app/portfolio/page.tsx` (ca
 
 ### Gradient Divider
 
-A 1px-tall rule where the leftmost 60px are brand red and the remainder fades to `slate-100`. Implemented as an `::after` pseudo-element on the `<header>`. Reserved for primary landmark boundaries only — overuse dilutes its impact.
+A 1px-tall rule where the leftmost 60px are brand red and the remainder fades to `zinc-100`. Implemented as an `::after` pseudo-element on the `<header>`. Reserved for primary landmark boundaries only — overuse dilutes its impact.
 
 ```tsx
 <header className="... relative
@@ -42,7 +42,7 @@ A 1px-tall rule where the leftmost 60px are brand red and the remainder fades to
   max-md:after:left-6 max-md:after:right-6
   after:h-px after:bg-gradient-to-r
   after:from-red after:from-[60px]
-  after:to-slate-100 after:to-[60px]">
+  after:to-zinc-100 after:to-[60px]">
 ```
 
 Used in: `src/components/Header.tsx`.
@@ -51,14 +51,14 @@ Used in: `src/components/Header.tsx`.
 
 ### Hairline Rules
 
-1px separators in `slate-100` or `slate-200` used throughout the system for rhythm and grouping. Never styled with color or shadow — always neutral.
+1px separators in `zinc-100` or `zinc-200` used throughout the system for rhythm and grouping. Never styled with color or shadow — always neutral.
 
 | Location | Implementation |
 |----------|---------------|
-| Footer top | `before:h-px before:bg-slate-100` pseudo-element |
-| PostExcerpt bottom | `border-b border-slate-100` (removed on last item via `last:border-b-0`) |
-| Pagination top | `border-t border-slate-100` |
-| Footnotes top | `border-top: 1px solid var(--color-slate-200)` in `.post-content` CSS |
+| Footer top | `before:h-px before:bg-zinc-100` pseudo-element |
+| PostExcerpt bottom | `border-b border-zinc-100` (removed on last item via `last:border-b-0`) |
+| Pagination top | `border-t border-zinc-100` |
+| Footnotes top | `border-top: 1px solid var(--color-zinc-200)` in `.post-content` CSS |
 
 Used in: `src/components/Footer.tsx`, `src/components/PostExcerpt.tsx`, `src/components/Pagination.tsx`, `src/app/globals.css`.
 
@@ -68,19 +68,19 @@ Used in: `src/components/Footer.tsx`, `src/components/PostExcerpt.tsx`, `src/com
 
 ### Link Hover: Color Transition
 
-Navigation links, post titles, and social icons transition to brand red on hover. The default text color is `slate-700` or `slate-900`; the transition is `transition-colors`.
+Navigation links, post titles, and social icons transition to brand red on hover. The default text color is `zinc-700` or `zinc-900`; the transition is `transition-colors`.
 
 ```tsx
 // Desktop nav links
 className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase
-  text-slate-700 no-underline hover:text-red transition-colors"
+  text-zinc-700 no-underline hover:text-red transition-colors"
 
 // Post title in excerpt
-className="text-lg font-medium text-slate-900
+className="text-lg font-medium text-zinc-900
   no-underline hover:text-red transition-colors"
 
-// SocialLinks icon (text-slate-500 at rest)
-className="text-slate-500 hover:text-red transition-colors"
+// SocialLinks icon (text-zinc-500 at rest)
+className="text-zinc-500 hover:text-red transition-colors"
 ```
 
 Used in: `src/components/Header.tsx`, `src/components/PostExcerpt.tsx`, `src/components/SocialLinks.tsx`, `src/components/Pagination.tsx`.
@@ -114,7 +114,7 @@ Portfolio cards use a `group` class on the link wrapper so that both the border 
 
 ```tsx
 <Link
-  className="group block p-8 border border-slate-200 rounded
+  className="group block p-8 border border-zinc-200 rounded
     hover:border-red transition-colors no-underline"
 >
   <h2 className="... group-hover:text-red transition-colors">
@@ -152,8 +152,8 @@ Used in: `src/app/contact/page.tsx`.
 Form inputs remove the browser default outline and replace it with a red border and a 1px red ring.
 
 ```tsx
-className="w-full px-4 py-3 border border-slate-200 rounded
-  text-sm text-slate-900 font-light
+className="w-full px-4 py-3 border border-zinc-200 rounded
+  text-sm text-zinc-900 font-light
   focus:outline-none focus:border-red focus:ring-1 focus:ring-red
   transition-colors"
 ```
@@ -226,7 +226,7 @@ A horizontal flex row of uppercase tracking links, hidden below the `md` breakpo
 ```tsx
 <nav className="hidden md:flex gap-9 items-center">
   <Link className="text-[0.78rem] font-[450] tracking-[0.1em]
-    uppercase text-slate-700 no-underline hover:text-red transition-colors">
+    uppercase text-zinc-700 no-underline hover:text-red transition-colors">
     Blog
   </Link>
   {/* … */}
@@ -280,19 +280,19 @@ Used in: `src/components/MobileNav.tsx`.
 Each post in a list is an `<article>` with a meta row, title link, and optional excerpt text.
 
 ```tsx
-<article className="py-6 border-b border-slate-100 last:border-b-0">
+<article className="py-6 border-b border-zinc-100 last:border-b-0">
   {/* Meta row */}
   <div className="flex items-center gap-3 mb-2">
-    <time className="text-xs text-slate-500 tracking-wide">{date}</time>
-    <span className="text-slate-300">&middot;</span>
+    <time className="text-xs text-zinc-500 tracking-wide">{date}</time>
+    <span className="text-zinc-300">&middot;</span>
     <Link className="text-xs text-red tracking-wider uppercase
       no-underline hover:opacity-70 transition-opacity">{category}</Link>
   </div>
   {/* Title */}
-  <Link className="text-lg font-medium text-slate-900
+  <Link className="text-lg font-medium text-zinc-900
     no-underline hover:text-red transition-colors">{title}</Link>
   {/* Excerpt */}
-  <p className="text-sm text-slate-600 leading-relaxed mt-2 font-light">{excerpt}</p>
+  <p className="text-sm text-zinc-600 leading-relaxed mt-2 font-light">{excerpt}</p>
 </article>
 ```
 
@@ -302,17 +302,17 @@ Used in: `src/components/PostExcerpt.tsx`.
 
 ### Post Metadata Block
 
-The metadata block at the top of a full post. Wraps with `flex-wrap` to handle multiple tags gracefully. Categories are red (opacity-dim hover); tags are slate-400 (color-transition hover).
+The metadata block at the top of a full post. Wraps with `flex-wrap` to handle multiple tags gracefully. Categories are red (opacity-dim hover); tags are zinc-400 (color-transition hover).
 
 ```tsx
 <div className="flex flex-wrap items-center gap-x-3 gap-y-1
-  text-xs text-slate-500 mb-8">
+  text-xs text-zinc-500 mb-8">
   <time>{date}</time>
   {/* Categories: red, uppercase */}
   <Link className="text-red no-underline hover:opacity-70
     transition-opacity uppercase tracking-wider">{category}</Link>
-  {/* Tags: slate-400, hash-prefixed */}
-  <Link className="text-slate-400 no-underline hover:text-red
+  {/* Tags: zinc-400, hash-prefixed */}
+  <Link className="text-zinc-400 no-underline hover:text-red
     transition-colors">#{tag}</Link>
 </div>
 ```
@@ -333,7 +333,7 @@ A semantic `<figure>` wrapping a Next.js `<Image>` with an optional centered cap
     className="w-full h-auto rounded"
   />
   {caption && (
-    <figcaption className="text-sm text-slate-500 mt-2 text-center">
+    <figcaption className="text-sm text-zinc-500 mt-2 text-center">
       {caption}
     </figcaption>
   )}
@@ -356,17 +356,17 @@ The `.post-content` class in `globals.css` governs typographic treatment of MDX 
   & a { color: var(--color-red); text-decoration: none; }
   & a:hover { opacity: 0.7; }
 
-  /* Blockquotes: red left border, slate-600 text */
-  & blockquote { border-left-color: var(--color-red); color: var(--color-slate-600); }
+  /* Blockquotes: red left border, zinc-600 text */
+  & blockquote { border-left-color: var(--color-red); color: var(--color-zinc-600); }
 
   /* Inline code: 0.875em */
   & code { font-size: 0.875em; }
 
-  /* Code blocks: slate-50 background, slate-200 border */
-  & pre { background: var(--color-slate-50); border: 1px solid var(--color-slate-200); }
+  /* Code blocks: zinc-50 background, zinc-200 border */
+  & pre { background: var(--color-zinc-50); border: 1px solid var(--color-zinc-200); }
 
-  /* Footnotes: separated by slate-200 hairline */
-  & .footnotes { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--color-slate-200); }
+  /* Footnotes: separated by zinc-200 hairline */
+  & .footnotes { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--color-zinc-200); }
 }
 ```
 

--- a/docs/design/philosophy.md
+++ b/docs/design/philosophy.md
@@ -43,7 +43,7 @@ The Greek tradition contributes structural rigor:
 These principles manifest in concrete design choices:
 
 - **Red dots as visual punctuation.** The Prometheas logo ends with a red dot -- a deliberate period that functions as a brand mark. This motif extends throughout the site as accent dots, hover states, and interactive indicators. Red is never used casually; it always punctuates.
-- **Slate as atmosphere.** The cool gray palette (slate-50 through slate-900) provides tonal depth without warmth. Slate reads as serious, calm, and architectural -- like stone.
+- **Zinc as atmosphere.** The cool gray palette (zinc-50 through zinc-900) provides tonal depth without warmth. Zinc reads as serious, calm, and architectural -- like stone.
 - **White as canvas.** The background is not merely white; it is the canvas on which everything else is composed. White space is the most important "color" in the system.
 - **Borders, not shadows.** Hierarchy is established through hairline rules and subtle border distinctions, not drop shadows or elevation. This keeps the visual plane flat and honest -- nothing pretends to float above anything else.
 

--- a/docs/superpowers/plans/2026-04-19-dark-mode.md
+++ b/docs/superpowers/plans/2026-04-19-dark-mode.md
@@ -1,0 +1,1058 @@
+# Dark Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add dark mode with system tracking and three-state manual override (System/Light/Dark), migrating the palette from slate to zinc and introducing a full red accent scale.
+
+**Architecture:** CSS custom properties define semantic tokens (bg-base, text-primary, accent, etc.) that swap values via a `.dark` class on `<html>`. A ThemeProvider client component manages localStorage persistence, media query listening, and cross-tab sync. A blocking inline script prevents FOUC.
+
+**Tech Stack:** Next.js App Router, Tailwind CSS v4 (CSS-first config), React Context, `rehype-pretty-code` dual-theme, `@tailwindcss/typography`
+
+**Spec:** `docs/superpowers/specs/2026-04-19-dark-mode-design.md`
+
+**Note on FOUC script:** The plan uses `dangerouslySetInnerHTML` with a static, hardcoded string for the FOUC prevention script in layout.tsx. This is a standard Next.js pattern — the content is not user-supplied and poses no XSS risk.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/app/globals.css` | Modify | Palette tokens, semantic vars, dark variant, prose overrides, selection/focus styles |
+| `src/app/layout.tsx` | Modify | ThemeProvider wrapper, FOUC script, suppressHydrationWarning |
+| `src/components/ThemeProvider.tsx` | Create | Context, localStorage, media query, cross-tab sync, color-scheme |
+| `src/components/ThemeToggle.tsx` | Create | Three-state cycle button with hydration safety |
+| `next.config.ts` | Modify | Dual syntax highlighting themes |
+| `src/components/Header.tsx` | Modify | Semantic colors, ThemeToggle placement |
+| `src/components/MobileNav.tsx` | Modify | Burger bar colors, ThemeToggle in menu |
+| `src/components/Footer.tsx` | Modify | Semantic colors |
+| `src/components/SocialLinks.tsx` | Modify | Semantic colors |
+| `src/app/page.tsx` | Modify | Semantic colors throughout |
+| `src/components/PostExcerpt.tsx` | Modify | Semantic colors |
+| `src/components/PostMeta.tsx` | Modify | Semantic colors |
+| `src/components/Pagination.tsx` | Modify | Semantic colors |
+| `src/components/Figure.tsx` | Modify | Semantic colors, dark mode border |
+| `src/app/posts/_components/PostList.tsx` | Modify | Semantic colors |
+| `src/app/posts/[year]/[month]/[slug]/page.tsx` | Modify | Semantic colors, remove prose-slate |
+| `src/app/about/page.tsx` | Modify | Semantic colors |
+| `src/app/contact/page.tsx` | Modify | Semantic colors, dark form inputs |
+| `src/app/portfolio/page.tsx` | Modify | Semantic colors |
+| `src/app/portfolio/software/page.tsx` | Modify | Semantic colors |
+| `src/app/portfolio/photography/page.tsx` | Modify | Semantic colors |
+| `src/app/portfolio/photography/PhotoGallery.tsx` | Modify | Semantic colors |
+| `DESIGN.md` | Modify | Slate → zinc references |
+| `docs/design/colors.md` | Modify | Zinc palette, red scale, semantic vars, dark mode |
+| `docs/design/components.md` | Modify | Slate → zinc references |
+| `docs/design/philosophy.md` | Modify | Slate → zinc references |
+
+---
+
+### Task 1: Palette Migration — globals.css
+
+**Files:**
+- Modify: `src/app/globals.css`
+
+- [ ] **Step 1: Replace slate tokens with zinc and add red scale, semantic vars, dark variant, prose overrides**
+
+Replace the entire `src/app/globals.css` with:
+
+```css
+@import "tailwindcss";
+@plugin "@tailwindcss/typography";
+@variant dark (&:where(.dark, .dark *));
+
+@theme inline {
+  /* Zinc palette (full Tailwind zinc) */
+  --color-zinc-50: #fafafa;
+  --color-zinc-100: #f4f4f5;
+  --color-zinc-200: #e4e4e7;
+  --color-zinc-300: #d4d4d8;
+  --color-zinc-400: #a1a1aa;
+  --color-zinc-500: #71717a;
+  --color-zinc-600: #52525b;
+  --color-zinc-700: #3f3f46;
+  --color-zinc-800: #27272a;
+  --color-zinc-900: #18181b;
+  --color-zinc-950: #09090b;
+
+  /* Red palette (hue 9, pinned at 600/700) */
+  --color-red-50: #fdf3f1;
+  --color-red-100: #fce3de;
+  --color-red-200: #f9cbc2;
+  --color-red-300: #f2a496;
+  --color-red-400: #ea7661;
+  --color-red-500: #df4e34;
+  --color-red-600: #C23B22;
+  --color-red-700: #A83019;
+  --color-red-800: #812818;
+  --color-red-900: #672418;
+  --color-red-950: #3e1109;
+
+  /* Legacy aliases for existing classes */
+  --color-red: #C23B22;
+  --color-red-hover: #A83019;
+
+  --font-sans: "Helvetica Neue", var(--font-inter), -apple-system, sans-serif;
+}
+
+/* Semantic tokens — light mode defaults */
+:root {
+  --bg-base: var(--color-zinc-50);
+  --bg-surface: #ffffff;
+  --bg-muted: var(--color-zinc-100);
+  --text-primary: var(--color-zinc-900);
+  --text-secondary: var(--color-zinc-500);
+  --text-muted: var(--color-zinc-500);
+  --border: var(--color-zinc-200);
+  --border-subtle: var(--color-zinc-100);
+  --accent: var(--color-red-600);
+  --accent-hover: var(--color-red-700);
+  color-scheme: light;
+}
+
+/* Semantic tokens — dark mode overrides */
+.dark {
+  --bg-base: var(--color-zinc-900);
+  --bg-surface: var(--color-zinc-800);
+  --bg-muted: var(--color-zinc-900);
+  --text-primary: var(--color-zinc-100);
+  --text-secondary: var(--color-zinc-400);
+  --text-muted: var(--color-zinc-400);
+  --border: var(--color-zinc-700);
+  --border-subtle: var(--color-zinc-700);
+  --accent: var(--color-red-400);
+  --accent-hover: var(--color-red-500);
+  color-scheme: dark;
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  background-color: var(--bg-base);
+  color: var(--text-primary);
+}
+
+/* Selection */
+::selection {
+  background-color: var(--accent);
+  color: white;
+}
+
+/* Focus rings */
+:focus-visible {
+  outline-color: var(--accent);
+}
+
+/* Prose overrides for semantic dark mode */
+.prose {
+  --tw-prose-body: var(--text-secondary);
+  --tw-prose-headings: var(--text-primary);
+  --tw-prose-links: var(--accent);
+  --tw-prose-bold: var(--text-primary);
+  --tw-prose-counters: var(--text-muted);
+  --tw-prose-bullets: var(--text-muted);
+  --tw-prose-hr: var(--border);
+  --tw-prose-quotes: var(--text-secondary);
+  --tw-prose-quote-borders: var(--accent);
+  --tw-prose-code: var(--text-primary);
+  --tw-prose-pre-code: var(--text-primary);
+  --tw-prose-pre-bg: var(--bg-muted);
+  --tw-prose-th-borders: var(--border);
+  --tw-prose-td-borders: var(--border-subtle);
+}
+
+/* Syntax highlighting: show only active theme */
+.dark [data-theme="light"],
+:not(.dark) [data-theme="dark"] {
+  display: none;
+}
+
+/* Blog post content */
+.post-content {
+  & p {
+    margin-top: 1em;
+    margin-bottom: 1em;
+  }
+
+  & a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+  & a:hover {
+    opacity: 0.7;
+  }
+  .dark & a:hover {
+    opacity: 1;
+    color: var(--accent-hover);
+  }
+
+  & blockquote {
+    border-left-color: var(--accent);
+    color: var(--text-secondary);
+  }
+
+  & code {
+    font-size: 0.875em;
+  }
+  & pre {
+    background: var(--bg-muted);
+    border: 1px solid var(--border);
+  }
+
+  & .footnotes {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+  }
+  & .footnotes h2 {
+    position: static !important;
+    width: auto !important;
+    height: auto !important;
+    padding: 0 !important;
+    margin: 0 0 1rem 0 !important;
+    overflow: visible !important;
+    clip: auto !important;
+    white-space: normal !important;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+  & .footnotes ol {
+    list-style-type: decimal;
+    padding-left: 1.5rem;
+  }
+  & .footnotes li {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+  }
+  & .footnotes li p {
+    margin: 0.25em 0;
+  }
+  & .data-footnote-backref {
+    font-size: 0.75rem;
+    margin-left: 0.25em;
+  }
+}
+```
+
+- [ ] **Step 2: Verify the dev server compiles without errors**
+
+Run: `npm run dev` (check terminal for compile errors)
+Expected: No errors. The site should look identical in light mode since zinc-50 bg replaces white bg and semantic vars default to light values.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/globals.css
+git commit -m "feat: migrate palette from slate to zinc, add red scale and semantic CSS vars"
+```
+
+---
+
+### Task 2: ThemeProvider Component
+
+**Files:**
+- Create: `src/components/ThemeProvider.tsx`
+
+- [ ] **Step 1: Create ThemeProvider**
+
+```tsx
+"use client";
+
+import { createContext, useContext, useEffect, useState, useCallback } from "react";
+
+type Theme = "system" | "light" | "dark";
+type ResolvedTheme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function getStoredTheme(): Theme {
+  if (typeof window === "undefined") return "system";
+  const stored = localStorage.getItem("theme");
+  if (stored === "light" || stored === "dark" || stored === "system") return stored;
+  return "system";
+}
+
+function applyTheme(resolved: ResolvedTheme) {
+  const root = document.documentElement;
+  if (resolved === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("system");
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light");
+
+  const resolve = useCallback((t: Theme): ResolvedTheme => {
+    return t === "system" ? getSystemTheme() : t;
+  }, []);
+
+  const setTheme = useCallback(
+    (newTheme: Theme) => {
+      setThemeState(newTheme);
+      localStorage.setItem("theme", newTheme);
+      const resolved = resolve(newTheme);
+      setResolvedTheme(resolved);
+      applyTheme(resolved);
+    },
+    [resolve],
+  );
+
+  // Initialize from localStorage on mount
+  useEffect(() => {
+    const stored = getStoredTheme();
+    setThemeState(stored);
+    const resolved = resolve(stored);
+    setResolvedTheme(resolved);
+    applyTheme(resolved);
+  }, [resolve]);
+
+  // Listen for system theme changes when in "system" mode
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => {
+      if (getStoredTheme() === "system") {
+        const resolved = getSystemTheme();
+        setResolvedTheme(resolved);
+        applyTheme(resolved);
+      }
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  // Cross-tab sync via storage event
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === "theme") {
+        const newTheme = (e.newValue as Theme) || "system";
+        setThemeState(newTheme);
+        const resolved = resolve(newTheme);
+        setResolvedTheme(resolved);
+        applyTheme(resolved);
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, [resolve]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) throw new Error("useTheme must be used within ThemeProvider");
+  return context;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/ThemeProvider.tsx
+git commit -m "feat: add ThemeProvider with localStorage, media query, and cross-tab sync"
+```
+
+---
+
+### Task 3: ThemeToggle Component
+
+**Files:**
+- Create: `src/components/ThemeToggle.tsx`
+
+- [ ] **Step 1: Create ThemeToggle**
+
+```tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "./ThemeProvider";
+
+const icons = {
+  light: (
+    <svg viewBox="0 0 20 20" fill="currentColor" className="w-[18px] h-[18px]">
+      <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" />
+    </svg>
+  ),
+  dark: (
+    <svg viewBox="0 0 20 20" fill="currentColor" className="w-[18px] h-[18px]">
+      <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+    </svg>
+  ),
+  system: (
+    <svg viewBox="0 0 20 20" fill="currentColor" className="w-[18px] h-[18px]">
+      <path fillRule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clipRule="evenodd" />
+    </svg>
+  ),
+};
+
+const cycle: Record<string, string> = {
+  system: "light",
+  light: "dark",
+  dark: "system",
+};
+
+const labels: Record<string, string> = {
+  system: "Theme: system. Click for light mode",
+  light: "Theme: light. Click for dark mode",
+  dark: "Theme: dark. Click for system mode",
+};
+
+export function ThemeToggle({ className = "" }: { className?: string }) {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return <span className={`inline-block w-[18px] h-[18px] ${className}`} />;
+  }
+
+  return (
+    <button
+      onClick={() => setTheme(cycle[theme] as "system" | "light" | "dark")}
+      aria-label={labels[theme]}
+      aria-live="polite"
+      className={`bg-transparent border-0 cursor-pointer p-0 text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors ${className}`}
+    >
+      {icons[theme]}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/ThemeToggle.tsx
+git commit -m "feat: add ThemeToggle with three-state cycle and hydration safety"
+```
+
+---
+
+### Task 4: Layout — FOUC Script and ThemeProvider
+
+**Files:**
+- Modify: `src/app/layout.tsx`
+
+- [ ] **Step 1: Update layout.tsx**
+
+Replace the entire file with:
+
+```tsx
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+import { ThemeProvider } from "@/components/ThemeProvider";
+import "./globals.css";
+
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+  title: {
+    default: "Prometheas.com",
+    template: "%s — Prometheas.com",
+  },
+  description:
+    "John Lianoglou's official personal website. Kneel before its majesty.",
+  metadataBase: new URL("https://prometheas.com"),
+  openGraph: {
+    siteName: "Prometheas.com",
+    type: "website",
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary",
+  },
+};
+
+// FOUC prevention: static inline script reads localStorage and applies .dark
+// class synchronously before first paint. Uses classList.add to preserve
+// next/font classes on <html>. Content is hardcoded — no XSS risk.
+const themeScript = `(function(){try{var t=localStorage.getItem("theme");if(t!=="light"&&t!=="dark"&&t!=="system")t="system";var d=t==="dark"||(t==="system"&&window.matchMedia("(prefers-color-scheme:dark)").matches);if(d)document.documentElement.classList.add("dark")}catch(e){}})()`;
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en" className={`${inter.variable} h-full antialiased`} suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+      </head>
+      <body className="min-h-full flex flex-col font-sans" suppressHydrationWarning>
+        <ThemeProvider>
+          <Header />
+          <main className="flex-1">{children}</main>
+          <Footer />
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+- [ ] **Step 2: Verify dev server loads without hydration warnings**
+
+Run: `npm run dev` — open browser console, check for React hydration warnings.
+Expected: No warnings. Page renders with correct theme based on system preference.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/layout.tsx
+git commit -m "feat: add FOUC prevention script and ThemeProvider to layout"
+```
+
+---
+
+### Task 5: Syntax Highlighting Dual Theme
+
+**Files:**
+- Modify: `next.config.ts`
+
+- [ ] **Step 1: Update rehype-pretty-code config**
+
+In `next.config.ts`, change line 17 from:
+
+```typescript
+rehypePlugins: [[rehypePrettyCode as any, { theme: "github-light" }]],
+```
+
+to:
+
+```typescript
+rehypePlugins: [[rehypePrettyCode as any, { theme: { light: "github-light", dark: "github-dark" } }]],
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add next.config.ts
+git commit -m "feat: add dual syntax highlighting themes for dark mode"
+```
+
+---
+
+### Task 6: Header and MobileNav — Semantic Colors + Toggle
+
+**Files:**
+- Modify: `src/components/Header.tsx`
+- Modify: `src/components/MobileNav.tsx`
+
+- [ ] **Step 1: Update Header.tsx**
+
+Replace entire file with:
+
+```tsx
+import Link from "next/link";
+import { SocialLinks } from "./SocialLinks";
+import { MobileNav } from "./MobileNav";
+import { ThemeToggle } from "./ThemeToggle";
+
+export function Header() {
+  return (
+    <header className="flex items-center justify-between px-[4.5rem] max-md:px-6 py-7 relative after:content-[''] after:absolute after:bottom-0 after:left-[4.5rem] after:right-[4.5rem] max-md:after:left-6 max-md:after:right-6 after:h-px after:bg-gradient-to-r after:from-[var(--accent)] after:from-[60px] after:to-[var(--border-subtle)] after:to-[60px]">
+      <Link
+        href="/"
+        className="text-[1.1rem] font-semibold tracking-[0.18em] uppercase text-[var(--text-primary)] no-underline"
+      >
+        Prometheas<span className="text-[var(--accent)] font-bold">.</span>com
+      </Link>
+
+      <nav className="hidden md:flex gap-9 items-center">
+        <Link
+          href="/posts/"
+          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
+        >
+          Blog
+        </Link>
+        <Link
+          href="/portfolio"
+          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
+        >
+          Portfolio
+        </Link>
+        <Link
+          href="/about"
+          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
+        >
+          About
+        </Link>
+        <Link
+          href="/contact"
+          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
+        >
+          Contact
+        </Link>
+        <ThemeToggle />
+      </nav>
+
+      <SocialLinks className="hidden md:flex" />
+      <MobileNav />
+    </header>
+  );
+}
+```
+
+- [ ] **Step 2: Update MobileNav.tsx**
+
+Replace `bg-black` burger bar classes with `bg-[var(--text-primary)]` for the closed state. Open state stays `bg-white` (bars on red curtain). Add ThemeToggle to the social links row.
+
+Replace entire file with:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ThemeToggle } from "./ThemeToggle";
+
+const socials = [
+  {
+    label: "LinkedIn",
+    href: "https://www.linkedin.com/in/prometheas",
+    icon: (
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    ),
+  },
+  {
+    label: "GitHub",
+    href: "https://github.com/prometheas",
+    icon: (
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    ),
+  },
+  {
+    label: "YouTube",
+    href: "https://www.youtube.com/user/prometheas",
+    icon: (
+      <path d="M23.498 6.186a3.016 3.016 0 00-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 00.502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 002.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 002.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+    ),
+  },
+];
+
+const navLinks = [
+  { href: "/posts/", label: "Blog" },
+  { href: "/portfolio", label: "Portfolio" },
+  { href: "/about", label: "About" },
+  { href: "/contact", label: "Contact" },
+] as const;
+
+export function MobileNav() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        className="md:hidden relative z-[1001] w-7 h-5 bg-transparent border-none cursor-pointer"
+        aria-label="Menu"
+        onClick={() => setOpen(!open)}
+      >
+        <span
+          className={`block absolute left-0 w-full h-[2px] transition-all duration-350 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+            open
+              ? "top-[9px] rotate-45 bg-white"
+              : "top-0 bg-[var(--text-primary)]"
+          }`}
+        />
+        <span
+          className={`block absolute left-0 w-full h-[2px] top-[9px] transition-all duration-350 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+            open ? "opacity-0 bg-white" : "bg-[var(--text-primary)]"
+          }`}
+        />
+        <span
+          className={`block absolute left-0 w-full h-[2px] transition-all duration-350 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+            open
+              ? "top-[9px] -rotate-45 bg-white"
+              : "top-[18px] bg-[var(--text-primary)]"
+          }`}
+        />
+      </button>
+
+      <div
+        className={`fixed inset-x-0 top-0 z-[1000] bg-red flex flex-col items-center justify-center gap-0 px-8 pt-20 pb-12 transition-all duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+          open
+            ? "translate-y-0 opacity-100 pointer-events-auto"
+            : "-translate-y-full opacity-0 pointer-events-none"
+        }`}
+      >
+        <div className="flex flex-col items-center gap-8 mb-12">
+          {navLinks.map((link, i) => {
+            const className = `text-2xl font-light tracking-[0.2em] uppercase text-white no-underline transition-all duration-300 ${
+              open
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 -translate-y-5"
+            }`;
+            const style = { transitionDelay: open ? `${150 + i * 70}ms` : "0ms" };
+
+            return "external" in link ? (
+              <a
+                key={link.href}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setOpen(false)}
+                className={className}
+                style={style}
+              >
+                {link.label}
+              </a>
+            ) : (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setOpen(false)}
+                className={className}
+                style={style}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        </div>
+
+        <div
+          className={`flex items-center gap-6 transition-all duration-300 ${
+            open
+              ? "opacity-100 translate-y-0"
+              : "opacity-0 -translate-y-2.5"
+          }`}
+          style={{ transitionDelay: open ? "350ms" : "0ms" }}
+        >
+          {socials.map((s) => (
+            <a
+              key={s.label}
+              href={s.href}
+              aria-label={s.label}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-white/70 hover:text-white transition-colors"
+            >
+              <svg viewBox="0 0 24 24" fill="currentColor" className="w-[22px] h-[22px]">
+                {s.icon}
+              </svg>
+            </a>
+          ))}
+          <ThemeToggle className="text-white/70 hover:text-white" />
+        </div>
+      </div>
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Verify header renders correctly in both themes**
+
+Toggle dark mode via the ThemeToggle. Check logo, nav links, gradient rule, and mobile menu.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Header.tsx src/components/MobileNav.tsx
+git commit -m "feat: update Header and MobileNav with semantic colors and ThemeToggle"
+```
+
+---
+
+### Task 7: Footer and SocialLinks — Semantic Colors
+
+**Files:**
+- Modify: `src/components/Footer.tsx`
+- Modify: `src/components/SocialLinks.tsx`
+
+- [ ] **Step 1: Update Footer.tsx**
+
+Replace entire file:
+
+```tsx
+import { SocialLinks } from "./SocialLinks";
+
+export function Footer() {
+  return (
+    <footer className="text-center px-[4.5rem] max-md:px-6 pt-10 pb-12 relative before:content-[''] before:absolute before:top-0 before:left-[4.5rem] before:right-[4.5rem] max-md:before:left-6 max-md:before:right-6 before:h-px before:bg-[var(--border-subtle)]">
+      <SocialLinks className="justify-center mb-3" />
+      <p className="text-xs text-[var(--text-muted)] font-light">
+        All material copyright &copy; 2001&ndash;{new Date().getFullYear()} John
+        Lianoglou, unless otherwise noted.
+      </p>
+    </footer>
+  );
+}
+```
+
+- [ ] **Step 2: Update SocialLinks.tsx line 35**
+
+Change the link className from:
+
+```tsx
+className="text-slate-500 hover:text-red transition-colors"
+```
+
+to:
+
+```tsx
+className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Footer.tsx src/components/SocialLinks.tsx
+git commit -m "feat: update Footer and SocialLinks with semantic colors"
+```
+
+---
+
+### Task 8: Homepage — Semantic Colors
+
+**Files:**
+- Modify: `src/app/page.tsx`
+
+- [ ] **Step 1: Apply color replacements**
+
+In `src/app/page.tsx`, apply these substitutions:
+
+| Current | Replacement |
+|---|---|
+| `text-slate-900` | `text-[var(--text-primary)]` |
+| `text-slate-700` | `text-[var(--text-secondary)]` |
+| `text-slate-500` | `text-[var(--text-secondary)]` |
+| `text-slate-300` | `text-[var(--text-muted)]` |
+| `bg-slate-200` | `bg-[var(--border)]` |
+| `border-slate-100` | `border-[var(--border-subtle)]` |
+| `via-slate-200` | `via-[var(--border)]` |
+| `text-red` (all occurrences) | `text-[var(--accent)]` |
+| `border-red` (dot ornament) | `border-[var(--accent)]` |
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/page.tsx
+git commit -m "feat: update homepage with semantic color tokens"
+```
+
+---
+
+### Task 9: Blog Components — Semantic Colors
+
+**Files:**
+- Modify: `src/components/PostExcerpt.tsx`
+- Modify: `src/components/PostMeta.tsx`
+- Modify: `src/components/Pagination.tsx`
+- Modify: `src/components/Figure.tsx`
+- Modify: `src/app/posts/_components/PostList.tsx`
+- Modify: `src/app/posts/[year]/[month]/[slug]/page.tsx`
+
+- [ ] **Step 1: Update PostExcerpt.tsx**
+
+| Current | Replacement |
+|---|---|
+| `border-slate-100` | `border-[var(--border-subtle)]` |
+| `text-slate-500` | `text-[var(--text-secondary)]` |
+| `text-slate-300` | `text-[var(--text-muted)]` |
+| `text-red` | `text-[var(--accent)]` |
+| `text-slate-900` | `text-[var(--text-primary)]` |
+| `hover:text-red` | `hover:text-[var(--accent)]` |
+| `text-slate-600` | `text-[var(--text-secondary)]` |
+
+- [ ] **Step 2: Update PostMeta.tsx**
+
+| Current | Replacement |
+|---|---|
+| `text-slate-500` | `text-[var(--text-secondary)]` |
+| `text-red` | `text-[var(--accent)]` |
+| `text-slate-400` | `text-[var(--text-muted)]` |
+| `hover:text-red` | `hover:text-[var(--accent)]` |
+
+- [ ] **Step 3: Update Pagination.tsx**
+
+| Current | Replacement |
+|---|---|
+| `border-slate-100` | `border-[var(--border-subtle)]` |
+| `text-slate-700` | `text-[var(--text-secondary)]` |
+| `text-slate-300` | `text-[var(--text-muted)]` |
+| `text-slate-400` | `text-[var(--text-muted)]` |
+| `hover:text-red` | `hover:text-[var(--accent)]` |
+
+- [ ] **Step 4: Update Figure.tsx**
+
+Change `text-slate-500` to `text-[var(--text-secondary)]`. Add dark mode image border:
+
+```tsx
+className="w-full h-auto rounded dark:border dark:border-[var(--border)]"
+```
+
+- [ ] **Step 5: Update PostList.tsx**
+
+| Current | Replacement |
+|---|---|
+| `text-slate-900` | `text-[var(--text-primary)]` |
+| `text-slate-500` | `text-[var(--text-secondary)]` |
+
+- [ ] **Step 6: Update blog post page**
+
+In `src/app/posts/[year]/[month]/[slug]/page.tsx`:
+- Line 52: `text-slate-900` → `text-[var(--text-primary)]`
+- Line 60: `prose prose-slate` → `prose` (remove `prose-slate`)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/PostExcerpt.tsx src/components/PostMeta.tsx src/components/Pagination.tsx src/components/Figure.tsx src/app/posts/_components/PostList.tsx "src/app/posts/[year]/[month]/[slug]/page.tsx"
+git commit -m "feat: update blog components with semantic color tokens"
+```
+
+---
+
+### Task 10: Portfolio, About, Contact Pages — Semantic Colors
+
+**Files:**
+- Modify: `src/app/about/page.tsx`
+- Modify: `src/app/contact/page.tsx`
+- Modify: `src/app/portfolio/page.tsx`
+- Modify: `src/app/portfolio/software/page.tsx`
+- Modify: `src/app/portfolio/photography/page.tsx`
+- Modify: `src/app/portfolio/photography/PhotoGallery.tsx`
+
+- [ ] **Step 1: Update about/page.tsx**
+
+| Current | Replacement |
+|---|---|
+| `text-slate-900` | `text-[var(--text-primary)]` |
+| `text-slate-700` | `text-[var(--text-secondary)]` |
+| `text-slate-500` | `text-[var(--text-secondary)]` |
+
+- [ ] **Step 2: Update contact/page.tsx**
+
+| Current | Replacement |
+|---|---|
+| `text-slate-900` | `text-[var(--text-primary)]` |
+| `text-slate-700` | `text-[var(--text-secondary)]` |
+| `text-slate-500` | `text-[var(--text-secondary)]` |
+| `border-slate-200` (inputs) | `border-[var(--border)]` |
+
+For form inputs, also add `bg-[var(--bg-surface)]` to the className. For the submit button, change `hover:bg-red-hover` to `hover:bg-[var(--accent-hover)]`.
+
+- [ ] **Step 3: Update portfolio/page.tsx**
+
+| Current | Replacement |
+|---|---|
+| `text-slate-900` | `text-[var(--text-primary)]` |
+| `text-slate-700` | `text-[var(--text-secondary)]` |
+| `text-slate-500` | `text-[var(--text-secondary)]` |
+| `border-slate-200` | `border-[var(--border)]` |
+| `hover:border-red` | `hover:border-[var(--accent)]` |
+| `hover:text-red` | `hover:text-[var(--accent)]` |
+| `border-red` (dot) | `border-[var(--accent)]` |
+
+- [ ] **Step 4: Update portfolio/software/page.tsx**
+
+Same substitutions as portfolio/page.tsx, plus `text-red` → `text-[var(--accent)]` for all project links.
+
+- [ ] **Step 5: Update portfolio/photography/page.tsx**
+
+`text-slate-900` → `text-[var(--text-primary)]`
+
+- [ ] **Step 6: Update PhotoGallery.tsx**
+
+`bg-slate-100` → `bg-[var(--bg-muted)]`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/about/page.tsx src/app/contact/page.tsx src/app/portfolio/page.tsx src/app/portfolio/software/page.tsx src/app/portfolio/photography/page.tsx src/app/portfolio/photography/PhotoGallery.tsx
+git commit -m "feat: update portfolio, about, and contact pages with semantic colors"
+```
+
+---
+
+### Task 11: Design Documentation Updates
+
+**Files:**
+- Modify: `DESIGN.md`
+- Modify: `docs/design/colors.md`
+- Modify: `docs/design/components.md`
+- Modify: `docs/design/philosophy.md`
+
+- [ ] **Step 1: Update all design docs**
+
+In each file, find-and-replace:
+- "slate" → "zinc" (in color context — verify each occurrence)
+- Update hex values from slate hex codes to zinc hex codes
+- In `colors.md`: add the full red scale table, the semantic variables table, and fill in the dark mode section
+- In `philosophy.md`: change "use cool slate exclusively" to "use zinc exclusively"
+- In `components.md`: update component color references and add dark mode behavior notes
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add DESIGN.md docs/design/colors.md docs/design/components.md docs/design/philosophy.md
+git commit -m "docs: update design documentation from slate to zinc with dark mode"
+```
+
+---
+
+### Task 12: Visual Verification
+
+- [ ] **Step 1: Full visual walkthrough — light mode**
+
+Navigate through every route and verify nothing has regressed:
+- Homepage (hero, columns, dividers, ornaments)
+- Blog index, paginated, category, tag, year pages
+- Individual blog post with code blocks, blockquotes, footnotes
+- About, Contact (form inputs, submit button), Portfolio, Software, Photography
+- Header, footer, social links on every page
+
+- [ ] **Step 2: Full visual walkthrough — dark mode**
+
+Toggle to dark mode. Verify:
+- Background is zinc-900, header is zinc-800 (raised)
+- Text hierarchy: zinc-100 headings, zinc-400 body/muted
+- Accent is red-400, hover is red-500
+- Code blocks: dark syntax highlighting visible, light hidden
+- Borders and dividers visible (zinc-700)
+- Form inputs have dark background and visible borders
+- Selection highlighting uses accent color
+- Focus rings use accent color
+- Red curtain mobile nav unaffected
+
+- [ ] **Step 3: System theme tracking**
+
+Set theme to "System". Change OS preference. Verify site follows.
+
+- [ ] **Step 4: Cross-tab sync**
+
+Open site in two tabs. Toggle theme in one. Verify the other updates.
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: visual adjustments from dark mode verification"
+```

--- a/docs/superpowers/plans/2026-04-19-dark-mode.md
+++ b/docs/superpowers/plans/2026-04-19-dark-mode.md
@@ -161,13 +161,15 @@ body {
 }
 
 /* Syntax highlighting: switch shiki theme via CSS vars */
-code[data-theme*=" "],
-code[data-theme*=" "] span {
+/* Note: use [data-rehype-pretty-code-figure] not code[data-theme*=" "]
+   because cssnano-simple can't parse the space in the attribute selector */
+[data-rehype-pretty-code-figure] code,
+[data-rehype-pretty-code-figure] code span {
   color: var(--shiki-light);
   background-color: var(--shiki-light-bg);
 }
-.dark code[data-theme*=" "],
-.dark code[data-theme*=" "] span {
+.dark [data-rehype-pretty-code-figure] code,
+.dark [data-rehype-pretty-code-figure] code span {
   color: var(--shiki-dark);
   background-color: var(--shiki-dark-bg);
 }

--- a/docs/superpowers/plans/2026-04-19-dark-mode.md
+++ b/docs/superpowers/plans/2026-04-19-dark-mode.md
@@ -59,7 +59,7 @@ Replace the entire `src/app/globals.css` with:
 ```css
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
-@variant dark (&:where(.dark, .dark *));
+@custom-variant dark (&:where(.dark, .dark *));
 
 @theme inline {
   /* Zinc palette (full Tailwind zinc) */
@@ -160,10 +160,16 @@ body {
   --tw-prose-td-borders: var(--border-subtle);
 }
 
-/* Syntax highlighting: show only active theme */
-.dark [data-theme="light"],
-:not(.dark) [data-theme="dark"] {
-  display: none;
+/* Syntax highlighting: switch shiki theme via CSS vars */
+code[data-theme*=" "],
+code[data-theme*=" "] span {
+  color: var(--shiki-light);
+  background-color: var(--shiki-light-bg);
+}
+.dark code[data-theme*=" "],
+.dark code[data-theme*=" "] span {
+  color: var(--shiki-dark);
+  background-color: var(--shiki-dark-bg);
 }
 
 /* Blog post content */
@@ -281,8 +287,12 @@ function getSystemTheme(): ResolvedTheme {
 
 function getStoredTheme(): Theme {
   if (typeof window === "undefined") return "system";
-  const stored = localStorage.getItem("theme");
-  if (stored === "light" || stored === "dark" || stored === "system") return stored;
+  try {
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark" || stored === "system") return stored;
+  } catch {
+    // localStorage unavailable (private browsing, restricted storage)
+  }
   return "system";
 }
 
@@ -290,8 +300,10 @@ function applyTheme(resolved: ResolvedTheme) {
   const root = document.documentElement;
   if (resolved === "dark") {
     root.classList.add("dark");
+    root.style.colorScheme = "dark";
   } else {
     root.classList.remove("dark");
+    root.style.colorScheme = "light";
   }
 }
 
@@ -306,7 +318,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const setTheme = useCallback(
     (newTheme: Theme) => {
       setThemeState(newTheme);
-      localStorage.setItem("theme", newTheme);
+      try { localStorage.setItem("theme", newTheme); } catch {}
       const resolved = resolve(newTheme);
       setResolvedTheme(resolved);
       applyTheme(resolved);
@@ -341,7 +353,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const handler = (e: StorageEvent) => {
       if (e.key === "theme") {
-        const newTheme = (e.newValue as Theme) || "system";
+        const raw = e.newValue;
+        const newTheme: Theme =
+          raw === "light" || raw === "dark" || raw === "system" ? raw : "system";
         setThemeState(newTheme);
         const resolved = resolve(newTheme);
         setResolvedTheme(resolved);
@@ -429,14 +443,18 @@ export function ThemeToggle({ className = "" }: { className?: string }) {
   }
 
   return (
-    <button
-      onClick={() => setTheme(cycle[theme] as "system" | "light" | "dark")}
-      aria-label={labels[theme]}
-      aria-live="polite"
-      className={`bg-transparent border-0 cursor-pointer p-0 text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors ${className}`}
-    >
-      {icons[theme]}
-    </button>
+    <>
+      <button
+        onClick={() => setTheme(cycle[theme] as "system" | "light" | "dark")}
+        aria-label={labels[theme]}
+        className={`bg-transparent border-0 cursor-pointer p-0 text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors ${className}`}
+      >
+        {icons[theme]}
+      </button>
+      <span className="sr-only" role="status" aria-live="polite">
+        {`Theme set to ${theme}`}
+      </span>
+    </>
   );
 }
 ```
@@ -493,7 +511,7 @@ export const metadata: Metadata = {
 // FOUC prevention: static inline script reads localStorage and applies .dark
 // class synchronously before first paint. Uses classList.add to preserve
 // next/font classes on <html>. Content is hardcoded — no XSS risk.
-const themeScript = `(function(){try{var t=localStorage.getItem("theme");if(t!=="light"&&t!=="dark"&&t!=="system")t="system";var d=t==="dark"||(t==="system"&&window.matchMedia("(prefers-color-scheme:dark)").matches);if(d)document.documentElement.classList.add("dark")}catch(e){}})()`;
+const themeScript = `(function(){var t="system";try{var s=localStorage.getItem("theme");if(s==="light"||s==="dark"||s==="system")t=s}catch(e){}var d=t==="dark"||(t!=="light"&&window.matchMedia("(prefers-color-scheme:dark)").matches);if(d){document.documentElement.classList.add("dark");document.documentElement.style.colorScheme="dark"}})()`;
 
 export default function RootLayout({
   children,
@@ -577,7 +595,7 @@ import { ThemeToggle } from "./ThemeToggle";
 
 export function Header() {
   return (
-    <header className="flex items-center justify-between px-[4.5rem] max-md:px-6 py-7 relative after:content-[''] after:absolute after:bottom-0 after:left-[4.5rem] after:right-[4.5rem] max-md:after:left-6 max-md:after:right-6 after:h-px after:bg-gradient-to-r after:from-[var(--accent)] after:from-[60px] after:to-[var(--border-subtle)] after:to-[60px]">
+    <header className="bg-[var(--bg-surface)] flex items-center justify-between px-[4.5rem] max-md:px-6 py-7 relative after:content-[''] after:absolute after:bottom-0 after:left-[4.5rem] after:right-[4.5rem] max-md:after:left-6 max-md:after:right-6 after:h-px after:bg-gradient-to-r after:from-[var(--accent)] after:from-[60px] after:to-[var(--border-subtle)] after:to-[60px]">
       <Link
         href="/"
         className="text-[1.1rem] font-semibold tracking-[0.18em] uppercase text-[var(--text-primary)] no-underline"
@@ -849,6 +867,7 @@ In `src/app/page.tsx`, apply these substitutions:
 | `via-slate-200` | `via-[var(--border)]` |
 | `text-red` (all occurrences) | `text-[var(--accent)]` |
 | `border-red` (dot ornament) | `border-[var(--accent)]` |
+| `hover:opacity-70` (accent links) | `hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)]` |
 
 - [ ] **Step 2: Commit**
 
@@ -880,6 +899,7 @@ git commit -m "feat: update homepage with semantic color tokens"
 | `text-slate-900` | `text-[var(--text-primary)]` |
 | `hover:text-red` | `hover:text-[var(--accent)]` |
 | `text-slate-600` | `text-[var(--text-secondary)]` |
+| `hover:opacity-70` (category link) | `hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)]` |
 
 - [ ] **Step 2: Update PostMeta.tsx**
 
@@ -889,6 +909,7 @@ git commit -m "feat: update homepage with semantic color tokens"
 | `text-red` | `text-[var(--accent)]` |
 | `text-slate-400` | `text-[var(--text-muted)]` |
 | `hover:text-red` | `hover:text-[var(--accent)]` |
+| `hover:opacity-70` (category link) | `hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)]` |
 
 - [ ] **Step 3: Update Pagination.tsx**
 
@@ -902,10 +923,37 @@ git commit -m "feat: update homepage with semantic color tokens"
 
 - [ ] **Step 4: Update Figure.tsx**
 
-Change `text-slate-500` to `text-[var(--text-secondary)]`. Add dark mode image border:
+Change `text-slate-500` to `text-[var(--text-secondary)]`. Add dark mode image border and optional `bgLight` prop for transparent PNGs:
 
 ```tsx
-className="w-full h-auto rounded dark:border dark:border-[var(--border)]"
+export function Figure({
+  src,
+  alt,
+  caption,
+  bgLight = false,
+}: {
+  src: string;
+  alt?: string;
+  caption?: string;
+  bgLight?: boolean;
+}) {
+  return (
+    <figure className="my-8">
+      <Image
+        src={src}
+        alt={alt || caption || ""}
+        width={800}
+        height={500}
+        className={`w-full h-auto rounded dark:border dark:border-[var(--border)] ${bgLight ? "dark:bg-white" : ""}`}
+      />
+      {caption && (
+        <figcaption className="text-sm text-[var(--text-secondary)] mt-2 text-center">
+          {caption}
+        </figcaption>
+      )}
+    </figure>
+  );
+}
 ```
 
 - [ ] **Step 5: Update PostList.tsx**
@@ -957,7 +1005,7 @@ git commit -m "feat: update blog components with semantic color tokens"
 | `text-slate-500` | `text-[var(--text-secondary)]` |
 | `border-slate-200` (inputs) | `border-[var(--border)]` |
 
-For form inputs, also add `bg-[var(--bg-surface)]` to the className. For the submit button, change `hover:bg-red-hover` to `hover:bg-[var(--accent-hover)]`.
+For form inputs, also add `bg-[var(--bg-surface)]` to the className. Change `focus:border-red focus:ring-red` to `focus:border-[var(--accent)] focus:ring-[var(--accent)]` on all three inputs. For the submit button, change `hover:bg-red-hover` to `hover:bg-[var(--accent-hover)]`.
 
 - [ ] **Step 3: Update portfolio/page.tsx**
 
@@ -973,7 +1021,7 @@ For form inputs, also add `bg-[var(--bg-surface)]` to the className. For the sub
 
 - [ ] **Step 4: Update portfolio/software/page.tsx**
 
-Same substitutions as portfolio/page.tsx, plus `text-red` → `text-[var(--accent)]` for all project links.
+Same substitutions as portfolio/page.tsx, plus `text-red` → `text-[var(--accent)]` for all project links. Also change `hover:opacity-70` on all project links to `hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)]`.
 
 - [ ] **Step 5: Update portfolio/photography/page.tsx**
 
@@ -982,6 +1030,8 @@ Same substitutions as portfolio/page.tsx, plus `text-red` → `text-[var(--accen
 - [ ] **Step 6: Update PhotoGallery.tsx**
 
 `bg-slate-100` → `bg-[var(--bg-muted)]`
+
+Note: The lightbox overlay (`bg-black/90`, `text-white`) is intentionally kept as-is — a dark overlay with white controls works correctly in both light and dark mode.
 
 - [ ] **Step 7: Commit**
 

--- a/docs/superpowers/specs/2026-04-19-dark-mode-design.md
+++ b/docs/superpowers/specs/2026-04-19-dark-mode-design.md
@@ -1,0 +1,200 @@
+# Dark Mode — Design Spec
+
+**Date:** April 19, 2026
+**Status:** Approved
+**Branch:** `spike/dark-mode`
+
+---
+
+## Summary
+
+Add dark mode to prometheas.com with system preference tracking and a manual three-state override (System / Light / Dark). The dark theme uses Tailwind's **zinc** palette as the neutral base and shifts the brand red one step lighter for contrast on dark backgrounds.
+
+---
+
+## Color System Changes
+
+### Palette Migration: Slate → Zinc
+
+Replace all slate tokens with the standard Tailwind **zinc** palette (50–950). Zinc has ~5% average saturation (vs slate's 35%), producing a near-neutral canvas that lets the brand red own the color.
+
+| Step | Zinc Hex  | Role (light) | Role (dark) |
+|------|-----------|--------------|-------------|
+| 50   | `#fafafa` | Page bg      | —           |
+| 100  | `#f4f4f5` | Section bg, code bg | —     |
+| 200  | `#e4e4e7` | Borders, dividers | —      |
+| 300  | `#d4d4d8` | Subtle decorative | —      |
+| 400  | `#a1a1aa` | Muted text   | Secondary text |
+| 500  | `#71717a` | Body text     | Muted text  |
+| 600  | `#52525b` | —            | —           |
+| 700  | `#3f3f46` | —            | Borders, dividers |
+| 800  | `#27272a` | —            | Surfaces (cards, header) |
+| 900  | `#18181b` | —            | Page bg     |
+| 950  | `#09090b` | —            | Deepest dark |
+
+### Red Scale (New)
+
+A full 50–950 red scale at hue 9°, with `#C23B22` pinned at step 600 and `#A83019` pinned at step 700.
+
+| Step | Hex       | Usage |
+|------|-----------|-------|
+| 50   | `#fdf3f1` | Tinted backgrounds |
+| 100  | `#fce3de` | Light tinted surfaces |
+| 200  | `#f9cbc2` | Borders, subtle accents |
+| 300  | `#f2a496` | Icons, secondary accents |
+| 400  | `#ea7661` | Dark mode hover state |
+| 500  | `#df4e34` | Dark mode primary accent |
+| 600  | `#C23B22` | Brand primary (pinned) |
+| 700  | `#A83019` | Light mode hover (pinned) |
+| 800  | `#812818` | Dark pressed states |
+| 900  | `#672418` | Dark surfaces with red tint |
+| 950  | `#3e1109` | Deepest red-tinted dark |
+
+### Semantic CSS Variables
+
+Defined in `globals.css`, swapped by `.dark` class on `<html>`.
+
+| Token | Light | Dark |
+|-------|-------|------|
+| `--bg-base` | zinc-50 (`#fafafa`) | zinc-900 (`#18181b`) |
+| `--bg-surface` | white (`#ffffff`) | zinc-800 (`#27272a`) |
+| `--bg-muted` | zinc-100 (`#f4f4f5`) | zinc-800 (`#27272a`) |
+| `--text-primary` | zinc-900 (`#18181b`) | zinc-100 (`#f4f4f5`) |
+| `--text-secondary` | zinc-500 (`#71717a`) | zinc-400 (`#a1a1aa`) |
+| `--text-muted` | zinc-400 (`#a1a1aa`) | zinc-500 (`#71717a`) |
+| `--border` | zinc-200 (`#e4e4e7`) | zinc-700 (`#3f3f46`) |
+| `--border-subtle` | zinc-100 (`#f4f4f5`) | zinc-800 (`#27272a`) |
+| `--accent` | red-600 (`#C23B22`) | red-500 (`#df4e34`) |
+| `--accent-hover` | red-700 (`#A83019`) | red-400 (`#ea7661`) |
+
+---
+
+## Theme Provider Architecture
+
+### ThemeProvider Component
+
+Client component wrapping `{children}` in `layout.tsx`.
+
+- Reads preference from `localStorage` key `theme` (values: `system`, `light`, `dark`)
+- Defaults to `system` on first visit
+- In `system` mode, listens to `window.matchMedia('(prefers-color-scheme: dark)')` changes
+- Sets/removes `.dark` class on `<html>` element
+- Exposes `{ theme, resolvedTheme, setTheme }` via React context
+  - `theme`: the stored preference (`system` | `light` | `dark`)
+  - `resolvedTheme`: the effective theme (`light` | `dark`)
+  - `setTheme(value)`: updates localStorage and applies immediately
+
+### FOUC Prevention
+
+A synchronous inline `<script>` in `<head>` (before CSS loads):
+
+```
+Read localStorage.theme
+If "dark" → add .dark to <html>
+If "system" or absent → check matchMedia('(prefers-color-scheme: dark)')
+  If matches → add .dark to <html>
+Otherwise → do nothing (light is the default)
+```
+
+This runs before first paint, so the page never flashes the wrong theme.
+
+### Tailwind v4 Dark Mode Configuration
+
+Configure class-based dark mode in `globals.css`:
+
+```css
+@variant dark (&:where(.dark, .dark *));
+```
+
+This enables `dark:` utilities throughout the codebase.
+
+---
+
+## Theme Toggle
+
+Three-state cycle button: Sun (light) → Moon (dark) → Monitor (system).
+
+- **Desktop:** Sits in the header nav bar, alongside existing nav links
+- **Mobile:** Appears inside the red curtain nav menu
+- Uses simple icon glyphs or minimal SVGs
+- Tooltip or aria-label indicates current state
+- Cycles on click: system → light → dark → system
+
+---
+
+## Component Migration
+
+Every component migrates from hardcoded slate/black/white classes to semantic CSS variables. The `dark:` Tailwind variant is available for edge cases.
+
+### Shared Components
+
+| Component | Changes |
+|---|---|
+| `globals.css` | Replace slate → zinc (full scale). Add red scale. Define semantic vars with `.dark` overrides. Configure `@variant dark`. Update `.post-content` selectors. |
+| `layout.tsx` | `bg-white text-black` → semantic vars. Add ThemeProvider wrapper. Add FOUC script to `<head>`. |
+| `Header.tsx` | `text-black` → `--text-primary`. `text-slate-700` → `--text-secondary`. Gradient rule: `to-slate-100` → `--border-subtle`. Add ThemeToggle. |
+| `MobileNav.tsx` | Red curtain stays red in both modes (brand element). Burger bars: `bg-black` → `--text-primary`. Add ThemeToggle inside menu. |
+| `Footer.tsx` | `text-slate-500` → `--text-muted`. `bg-slate-100` rule → `--border-subtle`. |
+| `SocialLinks.tsx` | `text-slate-500` → `--text-secondary`. `hover:text-red` → `--accent`. |
+
+### Homepage
+
+| Component | Changes |
+|---|---|
+| `page.tsx` | All `text-slate-*` → semantic vars. `bg-slate-200` dividers → `--border`. Column gradient `via-slate-200` → `--border`. Ornamental dots → `--border-subtle`. |
+
+### Blog Components
+
+| Component | Changes |
+|---|---|
+| `PostList.tsx` | `text-slate-900` heading → `--text-primary`. `text-slate-500` empty state → `--text-secondary`. |
+| `PostExcerpt.tsx` | Date → `--text-secondary`. Category → `--accent`. Title → `--text-primary`. Excerpt → `--text-secondary`. Border → `--border-subtle`. |
+| `PostMeta.tsx` | Date → `--text-secondary`. Category → `--accent`. Tags `text-slate-400` → `--text-muted`, hover → `--accent`. |
+| `Figure.tsx` | Caption → `--text-secondary`. |
+| `Pagination.tsx` | Links → `--text-secondary`, hover → `--accent`. Disabled → `--text-muted`. Counter → `--text-muted`. Border → `--border-subtle`. |
+
+### Blog Post Routes
+
+| Route | Changes |
+|---|---|
+| `posts/[year]/[month]/[slug]/page.tsx` | Heading → `--text-primary`. |
+| `posts/page.tsx`, `posts/category/[category]/page.tsx`, `posts/tag/[tag]/page.tsx`, `posts/year/[year]/page.tsx` | All delegate to PostList — no direct color references. |
+
+### Blog Prose (`.post-content`)
+
+All `.post-content` selectors migrate from hardcoded `var(--color-slate-*)` references to semantic variables. Since semantic vars swap automatically via the `.dark` class, no per-element dark overrides are needed:
+
+| Element | Current CSS | Migrates to |
+|---|---|---|
+| Links | `var(--color-red)` | `var(--accent)` |
+| Blockquote border | `var(--color-red)` | `var(--accent)` |
+| Blockquote text | `var(--color-slate-600)` | `var(--text-secondary)` |
+| Code block bg | `var(--color-slate-50)` | `var(--bg-muted)` |
+| Code block border | `var(--color-slate-200)` | `var(--border)` |
+| Footnote divider | `var(--color-slate-200)` | `var(--border)` |
+| Footnote heading | `var(--color-slate-900)` | `var(--text-primary)` |
+
+### Unchanged
+
+- **Mobile nav red curtain** — brand element, stays `bg-red` with white text in both modes
+- **Hero image** — photographic, no color adjustment needed
+- **Typography weights/sizes** — unchanged
+- **Layout structure** — unchanged
+- **Post redirect route** (`/post/[slug]`) — 301 redirect only, no visual
+
+---
+
+## New Files
+
+| File | Purpose |
+|---|---|
+| `src/components/ThemeProvider.tsx` | Context provider: localStorage + media query + `.dark` class management |
+| `src/components/ThemeToggle.tsx` | Three-state cycle button (sun/moon/monitor) |
+
+---
+
+## Implementation Notes
+
+- The slate → zinc migration is a global find-and-replace in both CSS tokens and Tailwind classes, done as a single atomic step before any dark mode logic is added.
+- Semantic CSS variables are consumed via `var(--token-name)` in CSS and via Tailwind's arbitrary value syntax `text-[var(--text-primary)]` in JSX — or by defining custom Tailwind utilities that map to the variables.
+- The FOUC script must be inline in `layout.tsx`'s `<head>`, not in an external file, to guarantee synchronous execution before first paint.

--- a/docs/superpowers/specs/2026-04-19-dark-mode-design.md
+++ b/docs/superpowers/specs/2026-04-19-dark-mode-design.md
@@ -161,7 +161,7 @@ This runs before first paint, so the page never flashes the wrong theme.
 Configure class-based dark mode in `globals.css`:
 
 ```css
-@variant dark (&:where(.dark, .dark *));
+@custom-variant dark (&:where(.dark, .dark *));
 ```
 
 This enables `dark:` utilities throughout the codebase.
@@ -255,11 +255,19 @@ rehypePlugins: [[rehypePrettyCode, {
 }]],
 ```
 
-This generates `data-theme="light"` and `data-theme="dark"` attributes on code blocks. CSS hides the inactive theme:
+This generates a single `<code data-theme="github-light github-dark">` element with `--shiki-light`/`--shiki-dark` CSS variables on each `<span>`. CSS switches the active theme:
 
 ```css
-.dark [data-theme="light"] { display: none; }
-:not(.dark) [data-theme="dark"] { display: none; }
+code[data-theme*=" "],
+code[data-theme*=" "] span {
+  color: var(--shiki-light);
+  background-color: var(--shiki-light-bg);
+}
+.dark code[data-theme*=" "],
+.dark code[data-theme*=" "] span {
+  color: var(--shiki-dark);
+  background-color: var(--shiki-dark-bg);
+}
 ```
 
 ### Tailwind Typography Plugin

--- a/docs/superpowers/specs/2026-04-19-dark-mode-design.md
+++ b/docs/superpowers/specs/2026-04-19-dark-mode-design.md
@@ -3,12 +3,13 @@
 **Date:** April 19, 2026
 **Status:** Approved
 **Branch:** `spike/dark-mode`
+**Reviewed by:** Codex adversarial review (all findings addressed)
 
 ---
 
 ## Summary
 
-Add dark mode to prometheas.com with system preference tracking and a manual three-state override (System / Light / Dark). The dark theme uses Tailwind's **zinc** palette as the neutral base and shifts the brand red one step lighter for contrast on dark backgrounds.
+Add dark mode to prometheas.com with system preference tracking and a manual three-state override (System / Light / Dark). The dark theme uses Tailwind's **zinc** palette as the neutral base and shifts the brand red two steps lighter for WCAG AA-compliant contrast on dark backgrounds.
 
 ---
 
@@ -18,18 +19,20 @@ Add dark mode to prometheas.com with system preference tracking and a manual thr
 
 Replace all slate tokens with the standard Tailwind **zinc** palette (50–950). Zinc has ~5% average saturation (vs slate's 35%), producing a near-neutral canvas that lets the brand red own the color.
 
+This migration also updates the design documentation (`DESIGN.md`, `docs/design/colors.md`, `docs/design/components.md`, `docs/design/philosophy.md`) to reference zinc instead of slate. The "use cool slate exclusively" guidance becomes "use zinc exclusively."
+
 | Step | Zinc Hex  | Role (light) | Role (dark) |
 |------|-----------|--------------|-------------|
 | 50   | `#fafafa` | Page bg      | —           |
 | 100  | `#f4f4f5` | Section bg, code bg | —     |
 | 200  | `#e4e4e7` | Borders, dividers | —      |
 | 300  | `#d4d4d8` | Subtle decorative | —      |
-| 400  | `#a1a1aa` | Muted text   | Secondary text |
-| 500  | `#71717a` | Body text     | Muted text  |
+| 400  | `#a1a1aa` | —            | Secondary text, muted text |
+| 500  | `#71717a` | Body text, muted text | —  |
 | 600  | `#52525b` | —            | —           |
-| 700  | `#3f3f46` | —            | Borders, dividers |
-| 800  | `#27272a` | —            | Surfaces (cards, header) |
-| 900  | `#18181b` | —            | Page bg     |
+| 700  | `#3f3f46` | —            | Borders, dividers, hairlines |
+| 800  | `#27272a` | —            | Raised surfaces (cards, header) |
+| 900  | `#18181b` | —            | Page bg, inset surfaces (code blocks) |
 | 950  | `#09090b` | —            | Deepest dark |
 
 ### Red Scale (New)
@@ -42,9 +45,9 @@ A full 50–950 red scale at hue 9°, with `#C23B22` pinned at step 600 and `#A8
 | 100  | `#fce3de` | Light tinted surfaces |
 | 200  | `#f9cbc2` | Borders, subtle accents |
 | 300  | `#f2a496` | Icons, secondary accents |
-| 400  | `#ea7661` | Dark mode hover state |
-| 500  | `#df4e34` | Dark mode primary accent |
-| 600  | `#C23B22` | Brand primary (pinned) |
+| 400  | `#ea7661` | Dark mode primary accent (6.13:1 on zinc-900) |
+| 500  | `#df4e34` | Dark mode hover state |
+| 600  | `#C23B22` | Brand primary (pinned) — light mode links/buttons |
 | 700  | `#A83019` | Light mode hover (pinned) |
 | 800  | `#812818` | Dark pressed states |
 | 900  | `#672418` | Dark surfaces with red tint |
@@ -54,18 +57,42 @@ A full 50–950 red scale at hue 9°, with `#C23B22` pinned at step 600 and `#A8
 
 Defined in `globals.css`, swapped by `.dark` class on `<html>`.
 
-| Token | Light | Dark |
-|-------|-------|------|
-| `--bg-base` | zinc-50 (`#fafafa`) | zinc-900 (`#18181b`) |
-| `--bg-surface` | white (`#ffffff`) | zinc-800 (`#27272a`) |
-| `--bg-muted` | zinc-100 (`#f4f4f5`) | zinc-800 (`#27272a`) |
-| `--text-primary` | zinc-900 (`#18181b`) | zinc-100 (`#f4f4f5`) |
-| `--text-secondary` | zinc-500 (`#71717a`) | zinc-400 (`#a1a1aa`) |
-| `--text-muted` | zinc-400 (`#a1a1aa`) | zinc-500 (`#71717a`) |
-| `--border` | zinc-200 (`#e4e4e7`) | zinc-700 (`#3f3f46`) |
-| `--border-subtle` | zinc-100 (`#f4f4f5`) | zinc-800 (`#27272a`) |
-| `--accent` | red-600 (`#C23B22`) | red-500 (`#df4e34`) |
-| `--accent-hover` | red-700 (`#A83019`) | red-400 (`#ea7661`) |
+| Token | Light | Dark | AA Contrast |
+|-------|-------|------|-------------|
+| `--bg-base` | zinc-50 (`#fafafa`) | zinc-900 (`#18181b`) | — |
+| `--bg-surface` | white (`#ffffff`) | zinc-800 (`#27272a`) | 1.19:1 vs base (subtle elevation) |
+| `--bg-muted` | zinc-100 (`#f4f4f5`) | zinc-900 (`#18181b`) | Inset on surface, not raised |
+| `--text-primary` | zinc-900 (`#18181b`) | zinc-100 (`#f4f4f5`) | 16.97:1 / 16.12:1 |
+| `--text-secondary` | zinc-500 (`#71717a`) | zinc-400 (`#a1a1aa`) | 4.63:1 / 6.91:1 |
+| `--text-muted` | zinc-500 (`#71717a`) | zinc-400 (`#a1a1aa`) | 4.63:1 / 6.91:1 |
+| `--border` | zinc-200 (`#e4e4e7`) | zinc-700 (`#3f3f46`) | — |
+| `--border-subtle` | zinc-100 (`#f4f4f5`) | zinc-700 (`#3f3f46`) | Visible on both base and surface |
+| `--accent` | red-600 (`#C23B22`) | red-400 (`#ea7661`) | 5.33:1 / 6.13:1 |
+| `--accent-hover` | red-700 (`#A83019`) | red-500 (`#df4e34`) | — / 4.45:1 (large text only) |
+
+**Key changes from initial draft (per adversarial review):**
+
+- `--accent` dark mode: red-500 → **red-400** (6.13:1 on zinc-900 vs 4.45:1 — now passes AA normal text)
+- `--accent-hover` dark mode: red-400 → **red-500** (hover is transient, AA large text sufficient)
+- `--text-muted` light mode: zinc-400 → **zinc-500** (4.63:1 vs 2.46:1 — was critically failing)
+- `--text-muted` and `--text-secondary` now share the same values (zinc-500 light / zinc-400 dark) — differentiation is achieved through font weight and context, not color
+- `--bg-muted` dark mode: zinc-800 → **zinc-900** (inset rather than raised, preserving visual hierarchy)
+- `--border-subtle` dark mode: zinc-800 → **zinc-700** (visible hairlines on both base and surface backgrounds)
+
+### Hover Strategy Change for Dark Mode
+
+The existing `hover:opacity-70` pattern drops contrast below AA on dark backgrounds. In dark mode, interactive hover uses a **color shift** (`--accent` → `--accent-hover`) instead of an opacity reduction. The `opacity-70` pattern is retained for light mode only.
+
+### `color-scheme` Property
+
+The FOUC script and ThemeProvider must also set the CSS `color-scheme` property on `<html>` to match the resolved theme:
+
+```css
+html { color-scheme: light; }
+html.dark { color-scheme: dark; }
+```
+
+This ensures native UA elements (scrollbars, form inputs, autofill backgrounds, `<select>` dropdowns) match the active theme.
 
 ---
 
@@ -73,16 +100,43 @@ Defined in `globals.css`, swapped by `.dark` class on `<html>`.
 
 ### ThemeProvider Component
 
-Client component wrapping `{children}` in `layout.tsx`.
+Client component wrapping the **entire `<body>` content** in `layout.tsx` — including Header and Footer, not just `{children}`. This ensures the toggle in Header/MobileNav can consume the theme context.
 
+```tsx
+<body suppressHydrationWarning className="...">
+  <ThemeProvider>
+    <Header />
+    <main className="flex-1">{children}</main>
+    <Footer />
+  </ThemeProvider>
+</body>
+```
+
+- `suppressHydrationWarning` on `<html>` and `<body>` prevents React warnings caused by the FOUC script modifying classes before hydration
+- The FOUC script must preserve existing classes on `<html>` (including `next/font` CSS variable classes) — it should **add** `.dark`, never replace `className`
+
+Provider behavior:
 - Reads preference from `localStorage` key `theme` (values: `system`, `light`, `dark`)
 - Defaults to `system` on first visit
+- Validates localStorage value — falls back to `system` if value is unrecognized
 - In `system` mode, listens to `window.matchMedia('(prefers-color-scheme: dark)')` changes
 - Sets/removes `.dark` class on `<html>` element
+- Sets `color-scheme` CSS property on `<html>`
+- Listens to `storage` event for cross-tab synchronization
 - Exposes `{ theme, resolvedTheme, setTheme }` via React context
   - `theme`: the stored preference (`system` | `light` | `dark`)
   - `resolvedTheme`: the effective theme (`light` | `dark`)
   - `setTheme(value)`: updates localStorage and applies immediately
+
+### Hydration Safety
+
+The ThemeToggle must use a `mounted` state guard to avoid rendering the wrong icon on the server:
+
+```tsx
+const [mounted, setMounted] = useState(false);
+useEffect(() => setMounted(true), []);
+if (!mounted) return <span className="w-5 h-5" />; // placeholder matching icon size
+```
 
 ### FOUC Prevention
 
@@ -90,10 +144,14 @@ A synchronous inline `<script>` in `<head>` (before CSS loads):
 
 ```
 Read localStorage.theme
-If "dark" → add .dark to <html>
+Validate: if not "system", "light", or "dark" → treat as "system"
+If "dark" → add .dark to <html>, set color-scheme: dark
 If "system" or absent → check matchMedia('(prefers-color-scheme: dark)')
-  If matches → add .dark to <html>
-Otherwise → do nothing (light is the default)
+  If matches → add .dark to <html>, set color-scheme: dark
+Otherwise → do nothing (light is the default, color-scheme: light via CSS)
+
+Important: use classList.add('dark'), not className assignment,
+to preserve next/font classes on <html>
 ```
 
 This runs before first paint, so the page never flashes the wrong theme.
@@ -116,9 +174,11 @@ Three-state cycle button: Sun (light) → Moon (dark) → Monitor (system).
 
 - **Desktop:** Sits in the header nav bar, alongside existing nav links
 - **Mobile:** Appears inside the red curtain nav menu
-- Uses simple icon glyphs or minimal SVGs
-- Tooltip or aria-label indicates current state
+- Uses simple SVG icons (sun, moon, monitor)
+- `aria-label` describes both current state and next action (e.g., "Theme: system. Click for light mode")
+- `role="button"` with `aria-live="polite"` so screen readers announce state changes
 - Cycles on click: system → light → dark → system
+- Uses `mounted` guard to prevent hydration mismatch (renders size-matched placeholder until client-side)
 
 ---
 
@@ -130,8 +190,8 @@ Every component migrates from hardcoded slate/black/white classes to semantic CS
 
 | Component | Changes |
 |---|---|
-| `globals.css` | Replace slate → zinc (full scale). Add red scale. Define semantic vars with `.dark` overrides. Configure `@variant dark`. Update `.post-content` selectors. |
-| `layout.tsx` | `bg-white text-black` → semantic vars. Add ThemeProvider wrapper. Add FOUC script to `<head>`. |
+| `globals.css` | Replace slate → zinc (full scale). Add red scale. Define semantic vars with `.dark` overrides. Add `color-scheme` rule. Configure `@variant dark`. Add `@plugin "@tailwindcss/typography"` dark mode config. Update `.post-content` selectors. |
+| `layout.tsx` | `bg-white text-black` → semantic vars. Restructure to wrap Header/Footer inside ThemeProvider. Add `suppressHydrationWarning` to `<html>` and `<body>`. Add FOUC script to `<head>`. |
 | `Header.tsx` | `text-black` → `--text-primary`. `text-slate-700` → `--text-secondary`. Gradient rule: `to-slate-100` → `--border-subtle`. Add ThemeToggle. |
 | `MobileNav.tsx` | Red curtain stays red in both modes (brand element). Burger bars: `bg-black` → `--text-primary`. Add ThemeToggle inside menu. |
 | `Footer.tsx` | `text-slate-500` → `--text-muted`. `bg-slate-100` rule → `--border-subtle`. |
@@ -157,12 +217,23 @@ Every component migrates from hardcoded slate/black/white classes to semantic CS
 
 | Route | Changes |
 |---|---|
-| `posts/[year]/[month]/[slug]/page.tsx` | Heading → `--text-primary`. |
+| `posts/[year]/[month]/[slug]/page.tsx` | Heading → `--text-primary`. Replace `prose-slate` with semantic prose overrides. |
 | `posts/page.tsx`, `posts/category/[category]/page.tsx`, `posts/tag/[tag]/page.tsx`, `posts/year/[year]/page.tsx` | All delegate to PostList — no direct color references. |
+
+### Portfolio, About, and Contact Pages
+
+| Route | Changes |
+|---|---|
+| `about/page.tsx` | All hardcoded slate/black text → semantic vars. |
+| `contact/page.tsx` | Form inputs: add dark mode border/bg/focus-ring styles. Text → semantic vars. |
+| `portfolio/page.tsx` | Text and card colors → semantic vars. |
+| `portfolio/software/page.tsx` | Project cards, text, borders → semantic vars. |
+| `portfolio/photography/page.tsx` | Text → semantic vars. |
+| `portfolio/photography/PhotoGallery.tsx` | Caption/overlay text → semantic vars. Image borders if any. |
 
 ### Blog Prose (`.post-content`)
 
-All `.post-content` selectors migrate from hardcoded `var(--color-slate-*)` references to semantic variables. Since semantic vars swap automatically via the `.dark` class, no per-element dark overrides are needed:
+All `.post-content` selectors migrate from hardcoded `var(--color-slate-*)` references to semantic variables. Since semantic vars swap automatically via the `.dark` class, no per-element dark overrides are needed for these elements:
 
 | Element | Current CSS | Migrates to |
 |---|---|---|
@@ -174,12 +245,76 @@ All `.post-content` selectors migrate from hardcoded `var(--color-slate-*)` refe
 | Footnote divider | `var(--color-slate-200)` | `var(--border)` |
 | Footnote heading | `var(--color-slate-900)` | `var(--text-primary)` |
 
+### Syntax Highlighting
+
+The project uses `rehype-pretty-code` with `theme: "github-light"` in `next.config.ts`. This must be updated to support dual themes:
+
+```ts
+rehypePlugins: [[rehypePrettyCode, {
+  theme: { light: "github-light", dark: "github-dark" },
+}]],
+```
+
+This generates `data-theme="light"` and `data-theme="dark"` attributes on code blocks. CSS hides the inactive theme:
+
+```css
+.dark [data-theme="light"] { display: none; }
+:not(.dark) [data-theme="dark"] { display: none; }
+```
+
+### Tailwind Typography Plugin
+
+The `@tailwindcss/typography` plugin applies `prose-slate` defaults. Override with semantic prose colors:
+
+```css
+.prose {
+  --tw-prose-body: var(--text-secondary);
+  --tw-prose-headings: var(--text-primary);
+  --tw-prose-links: var(--accent);
+  --tw-prose-bold: var(--text-primary);
+  --tw-prose-counters: var(--text-muted);
+  --tw-prose-bullets: var(--text-muted);
+  --tw-prose-hr: var(--border);
+  --tw-prose-quotes: var(--text-secondary);
+  --tw-prose-quote-borders: var(--accent);
+  --tw-prose-code: var(--text-primary);
+  --tw-prose-pre-code: var(--text-primary);
+  --tw-prose-pre-bg: var(--bg-muted);
+  --tw-prose-th-borders: var(--border);
+  --tw-prose-td-borders: var(--border-subtle);
+}
+```
+
+### Images and Figures
+
+- **Hero image:** Photographic, no adjustment needed.
+- **Blog images:** Most are screenshots or photos that work on both light and dark. For bright screenshots that look jarring on dark backgrounds, `Figure.tsx` applies a subtle border using `--border` to frame the image.
+- **Transparent PNGs:** Blog images with transparent backgrounds may need a light background applied in dark mode. Add a `bg-light` utility class for `Figure.tsx` that forces `background: white` regardless of theme, applied via an optional `bgLight` MDX prop.
+
+### Selection Styling
+
+```css
+::selection {
+  background-color: var(--accent);
+  color: white;
+}
+```
+
+### Focus Rings
+
+All interactive elements use `--accent` for focus ring color:
+
+```css
+:focus-visible {
+  outline-color: var(--accent);
+}
+```
+
 ### Unchanged
 
 - **Mobile nav red curtain** — brand element, stays `bg-red` with white text in both modes
-- **Hero image** — photographic, no color adjustment needed
 - **Typography weights/sizes** — unchanged
-- **Layout structure** — unchanged
+- **Layout structure** — unchanged (ThemeProvider wraps existing structure)
 - **Post redirect route** (`/post/[slug]`) — 301 redirect only, no visual
 
 ---
@@ -188,13 +323,27 @@ All `.post-content` selectors migrate from hardcoded `var(--color-slate-*)` refe
 
 | File | Purpose |
 |---|---|
-| `src/components/ThemeProvider.tsx` | Context provider: localStorage + media query + `.dark` class management |
-| `src/components/ThemeToggle.tsx` | Three-state cycle button (sun/moon/monitor) |
+| `src/components/ThemeProvider.tsx` | Context provider: localStorage + media query + `.dark` class + `color-scheme` + cross-tab sync |
+| `src/components/ThemeToggle.tsx` | Three-state cycle button with hydration safety and ARIA labels |
+
+---
+
+## Design Documentation Updates
+
+The following design docs must be updated alongside implementation to avoid a split-brain design system:
+
+| File | Changes |
+|---|---|
+| `DESIGN.md` | Replace all slate references with zinc. Update "cool slate exclusively" guidance. Add dark mode section. |
+| `docs/design/colors.md` | Replace slate palette with zinc. Add red scale. Document semantic variables and dark mode mappings. Fill in the reserved dark mode section. |
+| `docs/design/components.md` | Update all component color references from slate to zinc. Add dark mode behavior notes per component. |
+| `docs/design/philosophy.md` | Update "cool slate" references to zinc. |
 
 ---
 
 ## Implementation Notes
 
-- The slate → zinc migration is a global find-and-replace in both CSS tokens and Tailwind classes, done as a single atomic step before any dark mode logic is added.
+- The slate → zinc migration touches CSS tokens, Tailwind classes in JSX, and design docs. It must also catch `text-black`, `bg-white`, `bg-black`, and any `prose-slate` usage — a simple find-and-replace on "slate" alone is insufficient. Build a verification checklist by grepping for `slate`, `black`, `white`, and `prose` across all source files.
 - Semantic CSS variables are consumed via `var(--token-name)` in CSS and via Tailwind's arbitrary value syntax `text-[var(--text-primary)]` in JSX — or by defining custom Tailwind utilities that map to the variables.
-- The FOUC script must be inline in `layout.tsx`'s `<head>`, not in an external file, to guarantee synchronous execution before first paint.
+- The FOUC script must be inline in `layout.tsx`'s `<head>`, not in an external file, to guarantee synchronous execution before first paint. It must use `classList.add` (not `className =`) to preserve `next/font` classes.
+- The ThemeProvider wraps the full body content (Header + main + Footer) so the toggle can access context.

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,7 +14,7 @@ const withMDX = createMDX({
       remarkFrontmatter,
       remarkGfm,
     ],
-    rehypePlugins: [[rehypePrettyCode as any, { theme: "github-light" }]],
+    rehypePlugins: [[rehypePrettyCode as any, { theme: { light: "github-light", dark: "github-dark" } }]],
   },
 });
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = { title: "About" };
 export default function AboutPage() {
   return (
     <section className="max-w-[800px] mx-auto px-[4.5rem] max-md:px-6 py-20 max-md:py-12">
-      <h1 className="text-4xl max-md:text-3xl font-light text-slate-900 mb-12">
+      <h1 className="text-4xl max-md:text-3xl font-light text-[var(--text-primary)] mb-12">
         About
       </h1>
 
@@ -18,14 +18,14 @@ export default function AboutPage() {
           height={320}
           className="rounded"
         />
-        <p className="text-xs text-slate-500 mt-2 italic">
+        <p className="text-xs text-[var(--text-muted)] mt-2 italic">
           What I look like, when taking a selfie in front of a glacier
         </p>
       </div>
 
-      <h2 className="text-2xl font-medium text-slate-900 mb-6">Bio</h2>
+      <h2 className="text-2xl font-medium text-[var(--text-primary)] mb-6">Bio</h2>
 
-      <div className="text-[0.95rem] text-slate-700 leading-[1.85] font-light space-y-5">
+      <div className="text-[0.95rem] text-[var(--text-secondary)] leading-[1.85] font-light space-y-5">
         <p>
           John is a wordly, devilishly handsome, and cheeky internet software
           architect, with a strong background in designing and implementing

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -63,7 +63,7 @@ export default function ContactPage() {
 
         <button
           type="submit"
-          className="px-8 py-3 bg-red text-white text-sm font-medium tracking-wide uppercase rounded hover:bg-red-hover transition-colors cursor-pointer"
+          className="px-8 py-3 bg-red text-white text-sm font-medium tracking-wide uppercase rounded hover:bg-red-hover transition-colors cursor-pointer focus-visible:outline-white"
         >
           Send
         </button>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,14 +5,14 @@ export const metadata: Metadata = { title: "Contact" };
 export default function ContactPage() {
   return (
     <section className="max-w-[600px] mx-auto px-[4.5rem] max-md:px-6 py-20 max-md:py-12">
-      <h1 className="text-4xl max-md:text-3xl font-light text-slate-900 mb-2">
+      <h1 className="text-4xl max-md:text-3xl font-light text-[var(--text-primary)] mb-2">
         Contact
       </h1>
-      <p className="text-slate-500 font-light mb-10">
+      <p className="text-[var(--text-muted)] font-light mb-10">
         Reach out and touch someone. (Where that <em>someone</em> is me.)
       </p>
 
-      <h2 className="text-xl font-medium text-slate-900 mb-6">
+      <h2 className="text-xl font-medium text-[var(--text-primary)] mb-6">
         Send Me a Note
       </h2>
 
@@ -23,7 +23,7 @@ export default function ContactPage() {
         className="space-y-6"
       >
         <div>
-          <label htmlFor="name" className="block text-sm font-medium text-slate-700 mb-1.5">
+          <label htmlFor="name" className="block text-sm font-medium text-[var(--text-secondary)] mb-1.5">
             Name
           </label>
           <input
@@ -31,12 +31,12 @@ export default function ContactPage() {
             id="name"
             name="name"
             required
-            className="w-full px-4 py-3 border border-slate-200 rounded text-sm text-slate-900 font-light focus:outline-none focus:border-red focus:ring-1 focus:ring-red transition-colors"
+            className="w-full px-4 py-3 border border-[var(--border)] rounded text-sm text-[var(--text-primary)] bg-[var(--bg-surface)] font-light focus:outline-none focus:border-[var(--accent)] focus:ring-1 focus:ring-[var(--accent)] transition-colors"
           />
         </div>
 
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-slate-700 mb-1.5">
+          <label htmlFor="email" className="block text-sm font-medium text-[var(--text-secondary)] mb-1.5">
             Email
           </label>
           <input
@@ -44,12 +44,12 @@ export default function ContactPage() {
             id="email"
             name="email"
             required
-            className="w-full px-4 py-3 border border-slate-200 rounded text-sm text-slate-900 font-light focus:outline-none focus:border-red focus:ring-1 focus:ring-red transition-colors"
+            className="w-full px-4 py-3 border border-[var(--border)] rounded text-sm text-[var(--text-primary)] bg-[var(--bg-surface)] font-light focus:outline-none focus:border-[var(--accent)] focus:ring-1 focus:ring-[var(--accent)] transition-colors"
           />
         </div>
 
         <div>
-          <label htmlFor="message" className="block text-sm font-medium text-slate-700 mb-1.5">
+          <label htmlFor="message" className="block text-sm font-medium text-[var(--text-secondary)] mb-1.5">
             Message
           </label>
           <textarea
@@ -57,7 +57,7 @@ export default function ContactPage() {
             name="message"
             rows={6}
             required
-            className="w-full px-4 py-3 border border-slate-200 rounded text-sm text-slate-900 font-light focus:outline-none focus:border-red focus:ring-1 focus:ring-red transition-colors resize-y"
+            className="w-full px-4 py-3 border border-[var(--border)] rounded text-sm text-[var(--text-primary)] bg-[var(--bg-surface)] font-light focus:outline-none focus:border-[var(--accent)] focus:ring-1 focus:ring-[var(--accent)] transition-colors resize-y"
           />
         </div>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -102,13 +102,13 @@ body {
 }
 
 /* Syntax highlighting: switch shiki theme via CSS vars */
-code[data-theme*=" "],
-code[data-theme*=" "] span {
+[data-rehype-pretty-code-figure] code,
+[data-rehype-pretty-code-figure] code span {
   color: var(--shiki-light);
   background-color: var(--shiki-light-bg);
 }
-.dark code[data-theme*=" "],
-.dark code[data-theme*=" "] span {
+.dark [data-rehype-pretty-code-figure] code,
+.dark [data-rehype-pretty-code-figure] code span {
   color: var(--shiki-dark);
   background-color: var(--shiki-dark-bg);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,64 +1,156 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
+@custom-variant dark (&:where(.dark, .dark *));
 
 @theme inline {
+  /* Zinc palette (full Tailwind zinc) */
+  --color-zinc-50: #fafafa;
+  --color-zinc-100: #f4f4f5;
+  --color-zinc-200: #e4e4e7;
+  --color-zinc-300: #d4d4d8;
+  --color-zinc-400: #a1a1aa;
+  --color-zinc-500: #71717a;
+  --color-zinc-600: #52525b;
+  --color-zinc-700: #3f3f46;
+  --color-zinc-800: #27272a;
+  --color-zinc-900: #18181b;
+  --color-zinc-950: #09090b;
+
+  /* Red palette (hue 9, pinned at 600/700) */
+  --color-red-50: #fdf3f1;
+  --color-red-100: #fce3de;
+  --color-red-200: #f9cbc2;
+  --color-red-300: #f2a496;
+  --color-red-400: #ea7661;
+  --color-red-500: #df4e34;
+  --color-red-600: #C23B22;
+  --color-red-700: #A83019;
+  --color-red-800: #812818;
+  --color-red-900: #672418;
+  --color-red-950: #3e1109;
+
+  /* Legacy aliases for existing classes */
   --color-red: #C23B22;
   --color-red-hover: #A83019;
-  --color-slate-900: #0f172a;
-  --color-slate-700: #334155;
-  --color-slate-600: #475569;
-  --color-slate-500: #64748b;
-  --color-slate-300: #cbd5e1;
-  --color-slate-200: #e2e8f0;
-  --color-slate-100: #f1f5f9;
-  --color-slate-50: #f8fafc;
+
   --font-sans: "Helvetica Neue", var(--font-inter), -apple-system, sans-serif;
+}
+
+/* Semantic tokens — light mode defaults */
+:root {
+  --bg-base: var(--color-zinc-50);
+  --bg-surface: #ffffff;
+  --bg-muted: var(--color-zinc-100);
+  --text-primary: var(--color-zinc-900);
+  --text-secondary: var(--color-zinc-500);
+  --text-muted: var(--color-zinc-500);
+  --border: var(--color-zinc-200);
+  --border-subtle: var(--color-zinc-100);
+  --accent: var(--color-red-600);
+  --accent-hover: var(--color-red-700);
+  color-scheme: light;
+}
+
+/* Semantic tokens — dark mode overrides */
+.dark {
+  --bg-base: var(--color-zinc-900);
+  --bg-surface: var(--color-zinc-800);
+  --bg-muted: var(--color-zinc-900);
+  --text-primary: var(--color-zinc-100);
+  --text-secondary: var(--color-zinc-400);
+  --text-muted: var(--color-zinc-400);
+  --border: var(--color-zinc-700);
+  --border-subtle: var(--color-zinc-700);
+  --accent: var(--color-red-400);
+  --accent-hover: var(--color-red-500);
+  color-scheme: dark;
 }
 
 body {
   -webkit-font-smoothing: antialiased;
+  background-color: var(--bg-base);
+  color: var(--text-primary);
+}
+
+/* Selection */
+::selection {
+  background-color: var(--accent);
+  color: white;
+}
+
+/* Focus rings */
+:focus-visible {
+  outline-color: var(--accent);
+}
+
+/* Prose overrides for semantic dark mode */
+.prose {
+  --tw-prose-body: var(--text-secondary);
+  --tw-prose-headings: var(--text-primary);
+  --tw-prose-links: var(--accent);
+  --tw-prose-bold: var(--text-primary);
+  --tw-prose-counters: var(--text-muted);
+  --tw-prose-bullets: var(--text-muted);
+  --tw-prose-hr: var(--border);
+  --tw-prose-quotes: var(--text-secondary);
+  --tw-prose-quote-borders: var(--accent);
+  --tw-prose-code: var(--text-primary);
+  --tw-prose-pre-code: var(--text-primary);
+  --tw-prose-pre-bg: var(--bg-muted);
+  --tw-prose-th-borders: var(--border);
+  --tw-prose-td-borders: var(--border-subtle);
+}
+
+/* Syntax highlighting: switch shiki theme via CSS vars */
+code[data-theme*=" "],
+code[data-theme*=" "] span {
+  color: var(--shiki-light);
+  background-color: var(--shiki-light-bg);
+}
+.dark code[data-theme*=" "],
+.dark code[data-theme*=" "] span {
+  color: var(--shiki-dark);
+  background-color: var(--shiki-dark-bg);
 }
 
 /* Blog post content */
 .post-content {
-  /* Paragraph spacing: 1em between paragraphs */
   & p {
     margin-top: 1em;
     margin-bottom: 1em;
   }
 
-  /* Links */
   & a {
-    color: var(--color-red);
+    color: var(--accent);
     text-decoration: none;
   }
   & a:hover {
     opacity: 0.7;
   }
-
-  /* Blockquotes */
-  & blockquote {
-    border-left-color: var(--color-red);
-    color: var(--color-slate-600);
+  .dark & a:hover {
+    opacity: 1;
+    color: var(--accent-hover);
   }
 
-  /* Code blocks */
+  & blockquote {
+    border-left-color: var(--accent);
+    color: var(--text-secondary);
+  }
+
   & code {
     font-size: 0.875em;
   }
   & pre {
-    background: var(--color-slate-50);
-    border: 1px solid var(--color-slate-200);
+    background: var(--bg-muted);
+    border: 1px solid var(--border);
   }
 
-  /* Footnotes section */
   & .footnotes {
     margin-top: 3rem;
     padding-top: 1.5rem;
-    border-top: 1px solid var(--color-slate-200);
+    border-top: 1px solid var(--border);
   }
   & .footnotes h2 {
-    /* Override sr-only to make the heading visible */
     position: static !important;
     width: auto !important;
     height: auto !important;
@@ -69,7 +161,7 @@ body {
     white-space: normal !important;
     font-size: 0.875rem;
     font-weight: 600;
-    color: var(--color-slate-900);
+    color: var(--text-primary);
     letter-spacing: 0.05em;
     text-transform: uppercase;
   }
@@ -79,7 +171,7 @@ body {
   }
   & .footnotes li {
     font-size: 0.875rem;
-    color: var(--color-slate-600);
+    color: var(--text-secondary);
     line-height: 1.6;
   }
   & .footnotes li p {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,7 +42,7 @@
   --bg-surface: #ffffff;
   --bg-muted: var(--color-zinc-100);
   --text-primary: var(--color-zinc-900);
-  --text-secondary: var(--color-zinc-500);
+  --text-secondary: var(--color-zinc-600);
   --text-muted: var(--color-zinc-500);
   --border: var(--color-zinc-200);
   --border-subtle: var(--color-zinc-100);
@@ -80,7 +80,8 @@ body {
 
 /* Focus rings */
 :focus-visible {
-  outline-color: var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* Prose overrides for semantic dark mode */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -57,7 +57,7 @@
   --bg-surface: var(--color-zinc-800);
   --bg-muted: var(--color-zinc-900);
   --text-primary: var(--color-zinc-100);
-  --text-secondary: var(--color-zinc-400);
+  --text-secondary: var(--color-zinc-300);
   --text-muted: var(--color-zinc-400);
   --border: var(--color-zinc-700);
   --border-subtle: var(--color-zinc-700);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
+import { ThemeProvider } from "@/components/ThemeProvider";
 import "./globals.css";
 
 const inter = Inter({
@@ -27,17 +28,27 @@ export const metadata: Metadata = {
   },
 };
 
+// FOUC prevention: static inline script reads localStorage and applies .dark
+// class synchronously before first paint. Uses classList.add to preserve
+// next/font classes on <html>. Content is hardcoded — no XSS risk.
+const themeScript = `(function(){var t="system";try{var s=localStorage.getItem("theme");if(s==="light"||s==="dark"||s==="system")t=s}catch(e){}var d=t==="dark"||(t!=="light"&&window.matchMedia("(prefers-color-scheme:dark)").matches);if(d){document.documentElement.classList.add("dark");document.documentElement.style.colorScheme="dark"}})()`;
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${inter.variable} h-full antialiased`}>
-      <body className="min-h-full flex flex-col font-sans text-black bg-white">
-        <Header />
-        <main className="flex-1">{children}</main>
-        <Footer />
+    <html lang="en" className={`${inter.variable} h-full antialiased`} suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+      </head>
+      <body className="min-h-full flex flex-col font-sans" suppressHydrationWarning>
+        <ThemeProvider>
+          <Header />
+          <main className="flex-1">{children}</main>
+          <Footer />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
             width={1920}
             height={1200}
             priority
-            className="w-full h-auto block"
+            className="w-full h-auto block dark:opacity-[0.42]"
           />
         </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,13 +18,13 @@ export default function Home() {
         </div>
 
         <div className="px-[4.5rem] max-md:px-6 pb-20 max-md:pb-12 pt-12 max-md:pt-8">
-          <div className="text-[0.8rem] tracking-[0.25em] uppercase text-red font-medium mb-8">
+          <div className="text-[0.8rem] tracking-[0.25em] uppercase text-[var(--accent)] font-medium mb-8">
             Prometheas.com
           </div>
-          <h1 className="text-5xl max-md:text-[2.2rem] font-light leading-tight text-slate-900 mb-2">
+          <h1 className="text-5xl max-md:text-[2.2rem] font-light leading-tight text-[var(--text-primary)] mb-2">
             <strong className="font-semibold">John</strong> Lianoglou
           </h1>
-          <p className="text-[1.05rem] text-slate-500 max-w-[520px] leading-[1.8] font-light mt-6 mx-auto">
+          <p className="text-[1.05rem] text-[var(--text-muted)] max-w-[520px] leading-[1.8] font-light mt-6 mx-auto">
             Humanistic technologist. Software architect. Open source contributor
             since the early days. Building thoughtful things that serve people.
           </p>
@@ -35,11 +35,11 @@ export default function Home() {
       <section className="max-w-[1200px] mx-auto px-[4.5rem] max-md:px-6 pb-24 max-md:pb-16">
         {/* Ornament divider */}
         <div className="flex items-center gap-6 mb-14">
-          <div className="flex-1 h-px bg-slate-200" />
-          <div className="text-[0.7rem] tracking-[0.15em] text-slate-300 uppercase">
+          <div className="flex-1 h-px bg-[var(--border)]" />
+          <div className="text-[0.7rem] tracking-[0.15em] text-[var(--text-muted)] uppercase">
             &middot; &middot; &middot;
           </div>
-          <div className="flex-1 h-px bg-slate-200" />
+          <div className="flex-1 h-px bg-[var(--border)]" />
         </div>
 
         <div className="grid grid-cols-3 max-md:grid-cols-1">
@@ -51,11 +51,11 @@ export default function Home() {
             </p>
             <p className="mt-4">
               So far, I&apos;ve ported over my{" "}
-              <Link href="/portfolio/software" className="text-red no-underline hover:opacity-70 transition-opacity">
+              <Link href="/portfolio/software" className="text-[var(--accent)] no-underline hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity">
                 software projects
               </Link>{" "}
               showcase and a small sampling of my{" "}
-              <Link href="/portfolio/photography" className="text-red no-underline hover:opacity-70 transition-opacity">
+              <Link href="/portfolio/photography" className="text-[var(--accent)] no-underline hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity">
                 photography
               </Link>{" "}
               work (hobby only).
@@ -66,7 +66,7 @@ export default function Home() {
             <p>
               <Link
                 href="/posts/"
-                className="text-red no-underline hover:opacity-70 transition-opacity"
+                className="text-[var(--accent)] no-underline hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity"
               >
                 Uncarved
               </Link>{" "}
@@ -79,7 +79,7 @@ export default function Home() {
               Its name is a reference to{" "}
               <a
                 href="http://en.wikipedia.org/wiki/Uncarved_block#Pu"
-                className="text-red no-underline hover:opacity-70 transition-opacity"
+                className="text-[var(--accent)] no-underline hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -96,7 +96,7 @@ export default function Home() {
               You&apos;ll find direct links to my LinkedIn, Github, and other
               social profiles in the header and footer of this site. And the
               best way to get in touch is through{" "}
-              <Link href="/contact" className="text-red no-underline hover:opacity-70 transition-opacity">
+              <Link href="/contact" className="text-[var(--accent)] no-underline hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity">
                 this Contact form
               </Link>
               .
@@ -121,15 +121,15 @@ function Column({
     <div
       className={`py-10 px-12 max-md:px-0 max-md:py-8 relative ${
         !last
-          ? "max-md:border-b max-md:border-slate-100 after:max-md:hidden after:content-[''] after:absolute after:right-0 after:top-0 after:bottom-0 after:w-px after:bg-gradient-to-b after:from-transparent after:via-slate-200 after:to-transparent"
+          ? "max-md:border-b max-md:border-[var(--border-subtle)] after:max-md:hidden after:content-[''] after:absolute after:right-0 after:top-0 after:bottom-0 after:w-px after:bg-gradient-to-b after:from-transparent after:via-[var(--border)] after:to-transparent"
           : ""
       }`}
     >
-      <h2 className="text-[1.15rem] font-medium text-slate-900 mb-4 flex items-center gap-2.5">
-        <span className="w-2 h-2 border-[1.5px] border-red rounded-full shrink-0" />
+      <h2 className="text-[1.15rem] font-medium text-[var(--text-primary)] mb-4 flex items-center gap-2.5">
+        <span className="w-2 h-2 border-[1.5px] border-[var(--accent)] rounded-full shrink-0" />
         {title}
       </h2>
-      <div className="text-[0.92rem] text-slate-700 leading-[1.8] font-light">
+      <div className="text-[0.92rem] text-[var(--text-secondary)] leading-[1.8] font-light">
         {children}
       </div>
     </div>

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -6,36 +6,36 @@ export const metadata: Metadata = { title: "Portfolio" };
 export default function PortfolioPage() {
   return (
     <section className="max-w-[800px] mx-auto px-[4.5rem] max-md:px-6 py-20 max-md:py-12">
-      <h1 className="text-4xl max-md:text-3xl font-light text-slate-900 mb-6">
+      <h1 className="text-4xl max-md:text-3xl font-light text-[var(--text-primary)] mb-6">
         Portfolio
       </h1>
-      <p className="text-[0.95rem] text-slate-700 leading-[1.85] font-light mb-12">
+      <p className="text-[0.95rem] text-[var(--text-secondary)] leading-[1.85] font-light mb-12">
         A collection of my work, both professional and personal.
       </p>
 
       <div className="grid grid-cols-2 max-md:grid-cols-1 gap-8">
         <Link
           href="/portfolio/software"
-          className="group block p-8 border border-slate-200 rounded hover:border-red transition-colors no-underline"
+          className="group block p-8 border border-[var(--border)] rounded hover:border-[var(--accent)] transition-colors no-underline"
         >
-          <h2 className="text-xl font-medium text-slate-900 mb-2 flex items-center gap-2.5 group-hover:text-red transition-colors">
-            <span className="w-2 h-2 border-[1.5px] border-red rounded-full shrink-0" />
+          <h2 className="text-xl font-medium text-[var(--text-primary)] mb-2 flex items-center gap-2.5 group-hover:text-[var(--accent)] transition-colors">
+            <span className="w-2 h-2 border-[1.5px] border-[var(--accent)] rounded-full shrink-0" />
             Software Projects
           </h2>
-          <p className="text-sm text-slate-500 font-light leading-relaxed">
+          <p className="text-sm text-[var(--text-muted)] font-light leading-relaxed">
             Developer tools, browser extensions, and open source contributions spanning two decades.
           </p>
         </Link>
 
         <Link
           href="/portfolio/photography"
-          className="group block p-8 border border-slate-200 rounded hover:border-red transition-colors no-underline"
+          className="group block p-8 border border-[var(--border)] rounded hover:border-[var(--accent)] transition-colors no-underline"
         >
-          <h2 className="text-xl font-medium text-slate-900 mb-2 flex items-center gap-2.5 group-hover:text-red transition-colors">
-            <span className="w-2 h-2 border-[1.5px] border-red rounded-full shrink-0" />
+          <h2 className="text-xl font-medium text-[var(--text-primary)] mb-2 flex items-center gap-2.5 group-hover:text-[var(--accent)] transition-colors">
+            <span className="w-2 h-2 border-[1.5px] border-[var(--accent)] rounded-full shrink-0" />
             Photography
           </h2>
-          <p className="text-sm text-slate-500 font-light leading-relaxed">
+          <p className="text-sm text-[var(--text-muted)] font-light leading-relaxed">
             A small sampling of my photography work (hobby only).
           </p>
         </Link>

--- a/src/app/portfolio/photography/PhotoGallery.tsx
+++ b/src/app/portfolio/photography/PhotoGallery.tsx
@@ -20,7 +20,7 @@ export function PhotoGallery({ photos }: { photos: Photo[] }) {
           <button
             key={photo.src}
             onClick={() => setLightbox(i)}
-            className="relative overflow-hidden rounded cursor-pointer group bg-slate-100 border-0 p-0"
+            className="relative overflow-hidden rounded cursor-pointer group bg-[var(--bg-muted)] border-0 p-0"
           >
             <Image
               src={photo.src}

--- a/src/app/portfolio/photography/page.tsx
+++ b/src/app/portfolio/photography/page.tsx
@@ -15,7 +15,7 @@ const photos = [
 export default function PhotographyPage() {
   return (
     <section className="max-w-[1200px] mx-auto px-[4.5rem] max-md:px-6 py-20 max-md:py-12">
-      <h1 className="text-4xl max-md:text-3xl font-light text-slate-900 mb-12">
+      <h1 className="text-4xl max-md:text-3xl font-light text-[var(--text-primary)] mb-12">
         Photography
       </h1>
       <PhotoGallery photos={photos} />

--- a/src/app/portfolio/software/page.tsx
+++ b/src/app/portfolio/software/page.tsx
@@ -5,10 +5,10 @@ export const metadata: Metadata = { title: "Software Projects" };
 export default function SoftwarePage() {
   return (
     <section className="max-w-[800px] mx-auto px-[4.5rem] max-md:px-6 py-20 max-md:py-12">
-      <h1 className="text-4xl max-md:text-3xl font-light text-slate-900 mb-6">
+      <h1 className="text-4xl max-md:text-3xl font-light text-[var(--text-primary)] mb-6">
         Software Projects
       </h1>
-      <p className="text-[0.95rem] text-slate-700 leading-[1.85] font-light mb-12">
+      <p className="text-[0.95rem] text-[var(--text-secondary)] leading-[1.85] font-light mb-12">
         Here&apos;s an overview of some projects I&apos;ve been working on in my
         spare time, both contemporary and back into the archives.
       </p>
@@ -19,7 +19,7 @@ export default function SoftwarePage() {
           href="https://github.com/prometheas/generator-multistack-tdd-kata"
         >
           This is a{" "}
-          <a href="http://yeoman.io" className="text-red hover:opacity-70 transition-opacity" target="_blank" rel="noopener noreferrer">
+          <a href="http://yeoman.io" className="text-[var(--accent)] hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity" target="_blank" rel="noopener noreferrer">
             Yeoman
           </a>{" "}
           generator that quickly creates an empty TDD kata project. The
@@ -36,7 +36,7 @@ export default function SoftwarePage() {
           href="https://chrome.google.com/webstore/detail/jira-to-omnifocus/engmpfhepafobaopljohdkogmbbhcaeo"
         >
           for Chrome (
-          <a href="https://github.com/prometheas/jira-2-omnifocus" className="text-red hover:opacity-70 transition-opacity" target="_blank" rel="noopener noreferrer">
+          <a href="https://github.com/prometheas/jira-2-omnifocus" className="text-[var(--accent)] hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity" target="_blank" rel="noopener noreferrer">
             Github repo
           </a>
           ). This extension adds a big, lovely <em>Send to OmniFocus</em> button
@@ -49,26 +49,26 @@ export default function SoftwarePage() {
       </ProjectSection>
 
       <ProjectSection title="Deprecated and Obsolete">
-        <p className="text-[0.95rem] text-slate-700 leading-[1.85] font-light mb-6">
+        <p className="text-[0.95rem] text-[var(--text-secondary)] leading-[1.85] font-light mb-6">
           These are my older and, frankly, obsolete projects. They show a much
           less experienced man&apos;s skills, but I keep them around because they
           offer historical record that I&apos;ve been writing software as a
           hobby and releasing OSS for years. As rough their edges and long in the
           tooth, I&apos;m still rather proud of what they represent.
         </p>
-        <ul className="list-disc pl-6 space-y-3 text-[0.95rem] text-slate-700 leading-[1.85] font-light">
+        <ul className="list-disc pl-6 space-y-3 text-[0.95rem] text-[var(--text-secondary)] leading-[1.85] font-light">
           <li>
-            <a href="http://www.symfony-project.org/plugins/sfPropelLazyHydrationIteratorPlugin" className="text-red hover:opacity-70 transition-opacity" target="_blank" rel="noopener noreferrer">
+            <a href="http://www.symfony-project.org/plugins/sfPropelLazyHydrationIteratorPlugin" className="text-[var(--accent)] hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity" target="_blank" rel="noopener noreferrer">
               sfPropelLazyHydrationIteratorPlugin
             </a>
           </li>
           <li>
-            <a href="http://www.symfony-project.org/plugins/sfRESTClientPlugin" className="text-red hover:opacity-70 transition-opacity" target="_blank" rel="noopener noreferrer">
+            <a href="http://www.symfony-project.org/plugins/sfRESTClientPlugin" className="text-[var(--accent)] hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity" target="_blank" rel="noopener noreferrer">
               sfRESTClientPlugin
             </a>
           </li>
           <li>
-            <a href="https://sourceforge.net/projects/rosettastone/" className="text-red hover:opacity-70 transition-opacity" target="_blank" rel="noopener noreferrer">
+            <a href="https://sourceforge.net/projects/rosettastone/" className="text-[var(--accent)] hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity" target="_blank" rel="noopener noreferrer">
               Rosetta Stone Library
             </a>
             . A Swing (yep, Java) library that offered the ability to map
@@ -77,7 +77,7 @@ export default function SoftwarePage() {
             mid-aughts, so this has become entirely useless.
           </li>
           <li>
-            <a href="https://sourceforge.net/projects/awusbxtra/?source=directory" className="text-red hover:opacity-70 transition-opacity" target="_blank" rel="noopener noreferrer">
+            <a href="https://sourceforge.net/projects/awusbxtra/?source=directory" className="text-[var(--accent)] hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity" target="_blank" rel="noopener noreferrer">
               AWUSB Xtra
             </a>
             . An Xtra for Macromedia Director (yea, it&apos;s <em>that</em>{" "}
@@ -99,8 +99,8 @@ function ProjectSection({
 }) {
   return (
     <div className="mb-12">
-      <h2 className="text-xl font-medium text-slate-900 mb-4 flex items-center gap-2.5">
-        <span className="w-2 h-2 border-[1.5px] border-red rounded-full shrink-0" />
+      <h2 className="text-xl font-medium text-[var(--text-primary)] mb-4 flex items-center gap-2.5">
+        <span className="w-2 h-2 border-[1.5px] border-[var(--accent)] rounded-full shrink-0" />
         {title}
       </h2>
       {children}
@@ -118,8 +118,8 @@ function Project({
   children: React.ReactNode;
 }) {
   return (
-    <p className="text-[0.95rem] text-slate-700 leading-[1.85] font-light">
-      <a href={href} className="text-red font-medium hover:opacity-70 transition-opacity" target="_blank" rel="noopener noreferrer">
+    <p className="text-[0.95rem] text-[var(--text-secondary)] leading-[1.85] font-light">
+      <a href={href} className="text-[var(--accent)] font-medium hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity" target="_blank" rel="noopener noreferrer">
         {name}
       </a>
       . {children}

--- a/src/app/posts/[year]/[month]/[slug]/page.tsx
+++ b/src/app/posts/[year]/[month]/[slug]/page.tsx
@@ -49,7 +49,7 @@ export default async function PostPage({
 
   return (
     <article className="max-w-[720px] mx-auto px-[4.5rem] max-md:px-6 py-16 max-md:py-10">
-      <h1 className="text-3xl max-md:text-2xl font-semibold text-slate-900 leading-tight mb-4">
+      <h1 className="text-3xl max-md:text-2xl font-semibold text-[var(--text-primary)] leading-tight mb-4">
         {meta.title}
       </h1>
       <PostMetaComponent
@@ -57,7 +57,7 @@ export default async function PostPage({
         categories={meta.categories}
         tags={meta.tags}
       />
-      <div className="post-content prose prose-slate max-w-none">
+      <div className="post-content prose max-w-none">
         <Content />
       </div>
     </article>

--- a/src/app/posts/_components/PostList.tsx
+++ b/src/app/posts/_components/PostList.tsx
@@ -17,9 +17,9 @@ export function PostList({
 }) {
   return (
     <div className="max-w-[720px] mx-auto px-[4.5rem] max-md:px-6 py-16 max-md:py-10">
-      <h1 className="text-2xl font-semibold text-slate-900 mb-8">{title}</h1>
+      <h1 className="text-2xl font-semibold text-[var(--text-primary)] mb-8">{title}</h1>
       {posts.length === 0 ? (
-        <p className="text-slate-500">No posts found.</p>
+        <p className="text-[var(--text-muted)]">No posts found.</p>
       ) : (
         <>
           <div>

--- a/src/components/Figure.tsx
+++ b/src/components/Figure.tsx
@@ -4,10 +4,12 @@ export function Figure({
   src,
   alt,
   caption,
+  bgLight = false,
 }: {
   src: string;
   alt?: string;
   caption?: string;
+  bgLight?: boolean;
 }) {
   return (
     <figure className="my-8">
@@ -16,10 +18,10 @@ export function Figure({
         alt={alt || caption || ""}
         width={800}
         height={500}
-        className="w-full h-auto rounded"
+        className={`w-full h-auto rounded dark:border dark:border-[var(--border)] ${bgLight ? "dark:bg-white" : ""}`}
       />
       {caption && (
-        <figcaption className="text-sm text-slate-500 mt-2 text-center">
+        <figcaption className="text-sm text-[var(--text-secondary)] mt-2 text-center">
           {caption}
         </figcaption>
       )}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,9 +2,9 @@ import { SocialLinks } from "./SocialLinks";
 
 export function Footer() {
   return (
-    <footer className="text-center px-[4.5rem] max-md:px-6 pt-10 pb-12 relative before:content-[''] before:absolute before:top-0 before:left-[4.5rem] before:right-[4.5rem] max-md:before:left-6 max-md:before:right-6 before:h-px before:bg-slate-100">
+    <footer className="text-center px-[4.5rem] max-md:px-6 pt-10 pb-12 relative before:content-[''] before:absolute before:top-0 before:left-[4.5rem] before:right-[4.5rem] max-md:before:left-6 max-md:before:right-6 before:h-px before:bg-[var(--border-subtle)]">
       <SocialLinks className="justify-center mb-3" />
-      <p className="text-xs text-slate-500 font-light">
+      <p className="text-xs text-[var(--text-muted)] font-light">
         All material copyright &copy; 2001&ndash;{new Date().getFullYear()} John
         Lianoglou, unless otherwise noted.
       </p>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,9 +20,9 @@ export function Header() {
     <header className="bg-[var(--bg-surface)] flex items-center justify-between px-[4.5rem] max-md:px-6 py-7 relative after:content-[''] after:absolute after:bottom-0 after:left-[4.5rem] after:right-[4.5rem] max-md:after:left-6 max-md:after:right-6 after:h-px after:bg-gradient-to-r after:from-[var(--accent)] after:from-[60px] after:to-[var(--border-subtle)] after:to-[60px]">
       <Link
         href="/"
-        className="text-[1.1rem] font-semibold tracking-[0.18em] uppercase text-[var(--text-primary)] no-underline"
+        className="group text-[1.1rem] font-semibold tracking-[0.18em] uppercase text-[var(--text-primary)] no-underline hover:text-[var(--accent)] transition-colors"
       >
-        Prometheas<span className="text-[var(--accent)] font-bold">.</span>com
+        Prometheas<span className="text-[var(--accent)] group-hover:text-[var(--text-primary)] font-bold transition-colors">.</span>com
       </Link>
 
       <nav className="hidden md:flex gap-2 lg:gap-5 items-center">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ export function Header() {
         Prometheas<span className="text-[var(--accent)] font-bold">.</span>com
       </Link>
 
-      <nav className="hidden md:flex gap-9 items-center">
+      <nav className="hidden md:flex gap-6 lg:gap-9 items-center">
         <Link
           href="/posts/"
           className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
@@ -41,7 +41,7 @@ export function Header() {
         <ThemeToggle />
       </nav>
 
-      <SocialLinks className="hidden md:flex" />
+      <SocialLinks className="hidden lg:flex" />
       <MobileNav />
     </header>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,21 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { SocialLinks } from "./SocialLinks";
 import { MobileNav } from "./MobileNav";
 import { ThemeToggle } from "./ThemeToggle";
 
+const navLinks = [
+  { href: "/posts/", label: "Blog", match: "/posts" },
+  { href: "/portfolio", label: "Portfolio", match: "/portfolio" },
+  { href: "/about", label: "About", match: "/about" },
+  { href: "/contact", label: "Contact", match: "/contact" },
+] as const;
+
 export function Header() {
+  const pathname = usePathname();
+
   return (
     <header className="bg-[var(--bg-surface)] flex items-center justify-between px-[4.5rem] max-md:px-6 py-7 relative after:content-[''] after:absolute after:bottom-0 after:left-[4.5rem] after:right-[4.5rem] max-md:after:left-6 max-md:after:right-6 after:h-px after:bg-gradient-to-r after:from-[var(--accent)] after:from-[60px] after:to-[var(--border-subtle)] after:to-[60px]">
       <Link
@@ -14,30 +26,20 @@ export function Header() {
       </Link>
 
       <nav className="hidden md:flex gap-2 lg:gap-5 items-center">
-        <Link
-          href="/posts/"
-          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors py-2 px-2"
-        >
-          Blog
-        </Link>
-        <Link
-          href="/portfolio"
-          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors py-2 px-2"
-        >
-          Portfolio
-        </Link>
-        <Link
-          href="/about"
-          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors py-2 px-2"
-        >
-          About
-        </Link>
-        <Link
-          href="/contact"
-          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors py-2 px-2"
-        >
-          Contact
-        </Link>
+        {navLinks.map(({ href, label, match }) => {
+          const active = pathname.startsWith(match);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`text-[0.78rem] font-[450] tracking-[0.1em] uppercase no-underline hover:text-[var(--accent)] transition-colors py-2 px-2 ${
+                active ? "text-[var(--accent)]" : "text-[var(--text-secondary)]"
+              }`}
+            >
+              {label}
+            </Link>
+          );
+        })}
         <ThemeToggle />
       </nav>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,42 +1,44 @@
 import Link from "next/link";
 import { SocialLinks } from "./SocialLinks";
 import { MobileNav } from "./MobileNav";
+import { ThemeToggle } from "./ThemeToggle";
 
 export function Header() {
   return (
-    <header className="flex items-center justify-between px-[4.5rem] max-md:px-6 py-7 relative after:content-[''] after:absolute after:bottom-0 after:left-[4.5rem] after:right-[4.5rem] max-md:after:left-6 max-md:after:right-6 after:h-px after:bg-gradient-to-r after:from-red after:from-[60px] after:to-slate-100 after:to-[60px]">
+    <header className="bg-[var(--bg-surface)] flex items-center justify-between px-[4.5rem] max-md:px-6 py-7 relative after:content-[''] after:absolute after:bottom-0 after:left-[4.5rem] after:right-[4.5rem] max-md:after:left-6 max-md:after:right-6 after:h-px after:bg-gradient-to-r after:from-[var(--accent)] after:from-[60px] after:to-[var(--border-subtle)] after:to-[60px]">
       <Link
         href="/"
-        className="text-[1.1rem] font-semibold tracking-[0.18em] uppercase text-black no-underline"
+        className="text-[1.1rem] font-semibold tracking-[0.18em] uppercase text-[var(--text-primary)] no-underline"
       >
-        Prometheas<span className="text-red font-bold">.</span>com
+        Prometheas<span className="text-[var(--accent)] font-bold">.</span>com
       </Link>
 
       <nav className="hidden md:flex gap-9 items-center">
         <Link
           href="/posts/"
-          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-slate-700 no-underline hover:text-red transition-colors"
+          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
         >
           Blog
         </Link>
         <Link
           href="/portfolio"
-          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-slate-700 no-underline hover:text-red transition-colors"
+          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
         >
           Portfolio
         </Link>
         <Link
           href="/about"
-          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-slate-700 no-underline hover:text-red transition-colors"
+          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
         >
           About
         </Link>
         <Link
           href="/contact"
-          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-slate-700 no-underline hover:text-red transition-colors"
+          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
         >
           Contact
         </Link>
+        <ThemeToggle />
       </nav>
 
       <SocialLinks className="hidden md:flex" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,28 +13,28 @@ export function Header() {
         Prometheas<span className="text-[var(--accent)] font-bold">.</span>com
       </Link>
 
-      <nav className="hidden md:flex gap-6 lg:gap-9 items-center">
+      <nav className="hidden md:flex gap-2 lg:gap-5 items-center">
         <Link
           href="/posts/"
-          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
+          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors py-2 px-2"
         >
           Blog
         </Link>
         <Link
           href="/portfolio"
-          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
+          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors py-2 px-2"
         >
           Portfolio
         </Link>
         <Link
           href="/about"
-          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
+          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors py-2 px-2"
         >
           About
         </Link>
         <Link
           href="/contact"
-          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
+          className="text-[0.78rem] font-[450] tracking-[0.1em] uppercase text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors py-2 px-2"
         >
           Contact
         </Link>

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -41,33 +41,38 @@ export function MobileNav() {
   return (
     <>
       <button
-        className="md:hidden relative z-[1001] w-7 h-5 bg-transparent border-none cursor-pointer"
+        className="md:hidden z-[1001] flex items-center justify-center w-11 h-11 bg-transparent border-none cursor-pointer"
         aria-label="Menu"
+        aria-expanded={open}
+        aria-controls="mobile-nav"
         onClick={() => setOpen(!open)}
       >
-        <span
-          className={`block absolute left-0 w-full h-[2px] transition-all duration-350 ease-[cubic-bezier(0.4,0,0.2,1)] ${
-            open
-              ? "top-[9px] rotate-45 bg-white"
-              : "top-0 bg-[var(--text-primary)]"
-          }`}
-        />
-        <span
-          className={`block absolute left-0 w-full h-[2px] top-[9px] transition-all duration-350 ease-[cubic-bezier(0.4,0,0.2,1)] ${
-            open ? "opacity-0 bg-white" : "bg-[var(--text-primary)]"
-          }`}
-        />
-        <span
-          className={`block absolute left-0 w-full h-[2px] transition-all duration-350 ease-[cubic-bezier(0.4,0,0.2,1)] ${
-            open
-              ? "top-[9px] -rotate-45 bg-white"
-              : "top-[18px] bg-[var(--text-primary)]"
-          }`}
-        />
+        <span className="relative w-7 h-5 block">
+          <span
+            className={`block absolute left-0 w-full h-[2px] transition-all duration-350 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+              open
+                ? "top-[9px] rotate-45 bg-white"
+                : "top-0 bg-[var(--text-primary)]"
+            }`}
+          />
+          <span
+            className={`block absolute left-0 w-full h-[2px] top-[9px] transition-all duration-350 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+              open ? "opacity-0 bg-white" : "bg-[var(--text-primary)]"
+            }`}
+          />
+          <span
+            className={`block absolute left-0 w-full h-[2px] transition-all duration-350 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+              open
+                ? "top-[9px] -rotate-45 bg-white"
+                : "top-[18px] bg-[var(--text-primary)]"
+            }`}
+          />
+        </span>
       </button>
 
       <div
-        className={`fixed inset-x-0 top-0 z-[1000] bg-red flex flex-col items-center justify-center gap-0 px-8 pt-20 pb-12 transition-all duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+        id="mobile-nav"
+        className={`fixed inset-x-0 top-0 z-[1000] bg-red flex flex-col items-center justify-center gap-0 px-8 pt-20 pb-12 transition-all duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] [&_:focus-visible]:outline-white ${
           open
             ? "translate-y-0 opacity-100 pointer-events-auto"
             : "-translate-y-full opacity-0 pointer-events-none"

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { ThemeToggle } from "./ThemeToggle";
 
 const socials = [
   {
@@ -48,19 +49,19 @@ export function MobileNav() {
           className={`block absolute left-0 w-full h-[2px] transition-all duration-350 ease-[cubic-bezier(0.4,0,0.2,1)] ${
             open
               ? "top-[9px] rotate-45 bg-white"
-              : "top-0 bg-black"
+              : "top-0 bg-[var(--text-primary)]"
           }`}
         />
         <span
           className={`block absolute left-0 w-full h-[2px] top-[9px] transition-all duration-350 ease-[cubic-bezier(0.4,0,0.2,1)] ${
-            open ? "opacity-0 bg-white" : "bg-black"
+            open ? "opacity-0 bg-white" : "bg-[var(--text-primary)]"
           }`}
         />
         <span
           className={`block absolute left-0 w-full h-[2px] transition-all duration-350 ease-[cubic-bezier(0.4,0,0.2,1)] ${
             open
               ? "top-[9px] -rotate-45 bg-white"
-              : "top-[18px] bg-black"
+              : "top-[18px] bg-[var(--text-primary)]"
           }`}
         />
       </button>
@@ -108,7 +109,7 @@ export function MobileNav() {
         </div>
 
         <div
-          className={`flex gap-6 transition-all duration-300 ${
+          className={`flex items-center gap-6 transition-all duration-300 ${
             open
               ? "opacity-100 translate-y-0"
               : "opacity-0 -translate-y-2.5"
@@ -129,6 +130,7 @@ export function MobileNav() {
               </svg>
             </a>
           ))}
+          <ThemeToggle className="text-white/70 hover:text-white" />
         </div>
       </div>
     </>

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -16,31 +16,31 @@ export function Pagination({
   }
 
   return (
-    <nav className="flex items-center justify-center gap-6 pt-8 mt-4 border-t border-slate-100">
+    <nav className="flex items-center justify-center gap-6 pt-8 mt-4 border-t border-[var(--border-subtle)]">
       {currentPage > 1 ? (
         <Link
           href={pageUrl(currentPage - 1)}
-          className="text-sm text-slate-700 no-underline hover:text-red transition-colors"
+          className="text-sm text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
         >
           &larr; Newer
         </Link>
       ) : (
-        <span className="text-sm text-slate-300">&larr; Newer</span>
+        <span className="text-sm text-[var(--text-muted)]">&larr; Newer</span>
       )}
 
-      <span className="text-xs text-slate-400">
+      <span className="text-xs text-[var(--text-muted)]">
         {currentPage} / {totalPages}
       </span>
 
       {currentPage < totalPages ? (
         <Link
           href={pageUrl(currentPage + 1)}
-          className="text-sm text-slate-700 no-underline hover:text-red transition-colors"
+          className="text-sm text-[var(--text-secondary)] no-underline hover:text-[var(--accent)] transition-colors"
         >
           Older &rarr;
         </Link>
       ) : (
-        <span className="text-sm text-slate-300">Older &rarr;</span>
+        <span className="text-sm text-[var(--text-muted)]">Older &rarr;</span>
       )}
     </nav>
   );

--- a/src/components/PostExcerpt.tsx
+++ b/src/components/PostExcerpt.tsx
@@ -10,15 +10,15 @@ export function PostExcerpt({ post }: { post: PostMeta }) {
   });
 
   return (
-    <article className="py-6 border-b border-slate-100 last:border-b-0">
+    <article className="py-6 border-b border-[var(--border-subtle)] last:border-b-0">
       <div className="flex items-center gap-3 mb-2">
-        <time className="text-xs text-slate-500 tracking-wide">{formatted}</time>
+        <time className="text-xs text-[var(--text-muted)] tracking-wide">{formatted}</time>
         {post.categories[0] && (
           <>
-            <span className="text-slate-300">&middot;</span>
+            <span className="text-[var(--text-muted)]">&middot;</span>
             <Link
               href={`/posts/category/${encodeURIComponent(post.categories[0].toLowerCase())}`}
-              className="text-xs text-red tracking-wider uppercase no-underline hover:opacity-70 transition-opacity"
+              className="text-xs text-[var(--accent)] tracking-wider uppercase no-underline hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity"
             >
               {post.categories[0]}
             </Link>
@@ -27,12 +27,12 @@ export function PostExcerpt({ post }: { post: PostMeta }) {
       </div>
       <Link
         href={`/posts/${post.year}/${post.month}/${post.slug}`}
-        className="text-lg font-medium text-slate-900 no-underline hover:text-red transition-colors"
+        className="text-lg font-medium text-[var(--text-primary)] no-underline hover:text-[var(--accent)] transition-colors"
       >
         {post.title}
       </Link>
       {post.excerpt && (
-        <p className="text-sm text-slate-600 leading-relaxed mt-2 font-light">
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed mt-2 font-light">
           {post.excerpt}
         </p>
       )}

--- a/src/components/PostMeta.tsx
+++ b/src/components/PostMeta.tsx
@@ -16,13 +16,13 @@ export function PostMeta({
   });
 
   return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500 mb-8">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--text-muted)] mb-8">
       <time>{formatted}</time>
       {categories.map((c) => (
         <Link
           key={c}
           href={`/posts/category/${encodeURIComponent(c.toLowerCase())}`}
-          className="text-red no-underline hover:opacity-70 transition-opacity uppercase tracking-wider"
+          className="text-[var(--accent)] no-underline hover:opacity-70 dark:hover:opacity-100 dark:hover:text-[var(--accent-hover)] transition-opacity uppercase tracking-wider"
         >
           {c}
         </Link>
@@ -31,7 +31,7 @@ export function PostMeta({
         <Link
           key={t}
           href={`/posts/tag/${encodeURIComponent(t.toLowerCase())}`}
-          className="text-slate-400 no-underline hover:text-red transition-colors"
+          className="text-[var(--text-muted)] no-underline hover:text-[var(--accent)] transition-colors"
         >
           #{t}
         </Link>

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -32,7 +32,7 @@ export function SocialLinks({ className = "" }: { className?: string }) {
           aria-label={s.label}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-slate-500 hover:text-red transition-colors"
+          className="text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors"
         >
           <svg viewBox="0 0 24 24" fill="currentColor" className="w-[19px] h-[19px]">
             {s.icon}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, useCallback } from "react";
+
+type Theme = "system" | "light" | "dark";
+type ResolvedTheme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function getStoredTheme(): Theme {
+  if (typeof window === "undefined") return "system";
+  try {
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark" || stored === "system") return stored;
+  } catch {
+    // localStorage unavailable (private browsing, restricted storage)
+  }
+  return "system";
+}
+
+function applyTheme(resolved: ResolvedTheme) {
+  const root = document.documentElement;
+  if (resolved === "dark") {
+    root.classList.add("dark");
+    root.style.colorScheme = "dark";
+  } else {
+    root.classList.remove("dark");
+    root.style.colorScheme = "light";
+  }
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("system");
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light");
+
+  const resolve = useCallback((t: Theme): ResolvedTheme => {
+    return t === "system" ? getSystemTheme() : t;
+  }, []);
+
+  const setTheme = useCallback(
+    (newTheme: Theme) => {
+      setThemeState(newTheme);
+      try { localStorage.setItem("theme", newTheme); } catch {}
+      const resolved = resolve(newTheme);
+      setResolvedTheme(resolved);
+      applyTheme(resolved);
+    },
+    [resolve],
+  );
+
+  // Initialize from localStorage on mount
+  useEffect(() => {
+    const stored = getStoredTheme();
+    setThemeState(stored);
+    const resolved = resolve(stored);
+    setResolvedTheme(resolved);
+    applyTheme(resolved);
+  }, [resolve]);
+
+  // Listen for system theme changes when in "system" mode
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => {
+      if (getStoredTheme() === "system") {
+        const resolved = getSystemTheme();
+        setResolvedTheme(resolved);
+        applyTheme(resolved);
+      }
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  // Cross-tab sync via storage event
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === "theme") {
+        const raw = e.newValue;
+        const newTheme: Theme =
+          raw === "light" || raw === "dark" || raw === "system" ? raw : "system";
+        setThemeState(newTheme);
+        const resolved = resolve(newTheme);
+        setResolvedTheme(resolved);
+        applyTheme(resolved);
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, [resolve]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) throw new Error("useTheme must be used within ThemeProvider");
+  return context;
+}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState, useCallback } from "react";
+import { createContext, useContext, useEffect, useRef, useState, useCallback } from "react";
 
 type Theme = "system" | "light" | "dark";
 type ResolvedTheme = "light" | "dark";
@@ -43,6 +43,7 @@ function applyTheme(resolved: ResolvedTheme) {
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setThemeState] = useState<Theme>("system");
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light");
+  const themeRef = useRef<Theme>("system");
 
   const resolve = useCallback((t: Theme): ResolvedTheme => {
     return t === "system" ? getSystemTheme() : t;
@@ -50,6 +51,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   const setTheme = useCallback(
     (newTheme: Theme) => {
+      themeRef.current = newTheme;
       setThemeState(newTheme);
       try { localStorage.setItem("theme", newTheme); } catch {}
       const resolved = resolve(newTheme);
@@ -62,6 +64,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   // Initialize from localStorage on mount
   useEffect(() => {
     const stored = getStoredTheme();
+    themeRef.current = stored;
     setThemeState(stored);
     const resolved = resolve(stored);
     setResolvedTheme(resolved);
@@ -72,7 +75,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const handler = () => {
-      if (getStoredTheme() === "system") {
+      if (themeRef.current === "system") {
         const resolved = getSystemTheme();
         setResolvedTheme(resolved);
         applyTheme(resolved);
@@ -89,6 +92,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
         const raw = e.newValue;
         const newTheme: Theme =
           raw === "light" || raw === "dark" || raw === "system" ? raw : "system";
+        themeRef.current = newTheme;
         setThemeState(newTheme);
         const resolved = resolve(newTheme);
         setResolvedTheme(resolved);

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "./ThemeProvider";
+
+const icons = {
+  light: (
+    <svg viewBox="0 0 20 20" fill="currentColor" className="w-[18px] h-[18px]">
+      <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" />
+    </svg>
+  ),
+  dark: (
+    <svg viewBox="0 0 20 20" fill="currentColor" className="w-[18px] h-[18px]">
+      <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+    </svg>
+  ),
+  system: (
+    <svg viewBox="0 0 20 20" fill="currentColor" className="w-[18px] h-[18px]">
+      <path fillRule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clipRule="evenodd" />
+    </svg>
+  ),
+};
+
+const cycle: Record<string, string> = {
+  system: "light",
+  light: "dark",
+  dark: "system",
+};
+
+const labels: Record<string, string> = {
+  system: "Theme: system. Click for light mode",
+  light: "Theme: light. Click for dark mode",
+  dark: "Theme: dark. Click for system mode",
+};
+
+export function ThemeToggle({ className = "" }: { className?: string }) {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return <span className={`inline-block w-[18px] h-[18px] ${className}`} />;
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setTheme(cycle[theme] as "system" | "light" | "dark")}
+        aria-label={labels[theme]}
+        className={`bg-transparent border-0 cursor-pointer p-0 text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors ${className}`}
+      >
+        {icons[theme]}
+      </button>
+      <span className="sr-only" role="status" aria-live="polite">
+        {`Theme set to ${theme}`}
+      </span>
+    </>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTheme } from "./ThemeProvider";
 
 const icons = {
@@ -36,8 +36,17 @@ const labels: Record<string, string> = {
 export function ThemeToggle({ className = "" }: { className?: string }) {
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+  const [announcement, setAnnouncement] = useState("");
+  const prevTheme = useRef(theme);
 
   useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (mounted && prevTheme.current !== theme) {
+      setAnnouncement(`Theme set to ${theme}`);
+      prevTheme.current = theme;
+    }
+  }, [theme, mounted]);
 
   if (!mounted) {
     return <span className={`inline-block w-[34px] h-[34px] ${className}`} />;
@@ -54,7 +63,7 @@ export function ThemeToggle({ className = "" }: { className?: string }) {
         {icons[theme]}
       </button>
       <span className="sr-only" role="status" aria-live="polite">
-        {`Theme set to ${theme}`}
+        {announcement}
       </span>
     </>
   );

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -40,15 +40,16 @@ export function ThemeToggle({ className = "" }: { className?: string }) {
   useEffect(() => setMounted(true), []);
 
   if (!mounted) {
-    return <span className={`inline-block w-[18px] h-[18px] ${className}`} />;
+    return <span className={`inline-block w-[34px] h-[34px] ${className}`} />;
   }
 
   return (
     <>
       <button
+        type="button"
         onClick={() => setTheme(cycle[theme] as "system" | "light" | "dark")}
         aria-label={labels[theme]}
-        className={`bg-transparent border-0 cursor-pointer p-0 text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors ${className}`}
+        className={`bg-transparent border-0 cursor-pointer p-2 text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors ${className}`}
       >
         {icons[theme]}
       </button>


### PR DESCRIPTION
## Summary

- Adds dark mode with three-state toggle (System / Light / Dark) that tracks OS preference and persists to localStorage
- Migrates the entire color system from Tailwind slate to zinc (near-neutral gray) for a cleaner canvas
- Introduces a full red accent scale (50–950) at hue 9° with the brand red `#C23B22` pinned at step 600
- Defines semantic CSS custom properties (`--bg-base`, `--text-primary`, `--accent`, etc.) that swap via a `.dark` class on `<html>`
- All 22 source files migrated from hardcoded colors to semantic tokens
- WCAG AA contrast compliance verified for all token pairings
- Two Codex adversarial reviews with all findings addressed

## Key decisions

- **Zinc over slate**: chosen for ~5% saturation (vs slate's 35%) — lets the brand red own all the color
- **Red-400 as dark accent**: 6.13:1 contrast on zinc-900 (red-500 was only 4.45:1, failing AA)
- **ThemeProvider wraps full body**: Header/Footer inside provider so toggle can access context
- **FOUC prevention**: inline `<script>` with resilient localStorage fallback + `color-scheme` property
- **rehype-pretty-code dual themes**: uses `--shiki-light`/`--shiki-dark` CSS variable switching (not DOM duplication)
- **Hero image**: 42% opacity in dark mode for atmospheric integration

## New components

- `ThemeProvider.tsx` — React context, localStorage, media query listener, cross-tab sync, `color-scheme`
- `ThemeToggle.tsx` — three-state cycle button with hydration safety, ARIA live region

## Test plan

- [ ] Light mode: verify no visual regression across all routes (homepage, blog, about, contact, portfolio, photography)
- [ ] Dark mode: toggle via ThemeToggle, verify zinc-900 background, zinc-800 header surface, red-400 accent, zinc-300 body text
- [ ] System tracking: set to "System", change OS preference, verify site follows
- [ ] Cross-tab sync: toggle in one tab, verify other tabs update
- [ ] FOUC: hard-refresh in dark mode, verify no white flash
- [ ] Mobile: burger menu works, ThemeToggle visible in red curtain menu
- [ ] Blog post: code blocks render with correct syntax highlighting theme
- [ ] Active nav: correct nav item highlighted on each route
- [ ] Build: `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)