### PR TITLE
feat: add proxy.ts for uncarved subdomain 301 redirect

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,19 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+export function proxy(request: NextRequest) {
+  const host = request.headers.get("host") ?? "";
+
+  if (host === "uncarved.prometheas.com") {
+    const url = request.nextUrl.clone();
+    url.protocol = "https:";
+    url.host = "prometheas.com";
+    url.port = "";
+    return NextResponse.redirect(url, { status: 301 });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon\\.ico).*)"],
+};


### PR DESCRIPTION
## Summary

- Adds `src/proxy.ts` (Next.js 16 proxy) that 301 redirects all requests from `uncarved.prometheas.com` to `https://prometheas.com`, preserving path and query string
- Adds `uncarved.prometheas.com` to the Vercel `prometheas-com` project (done via CLI; required for Vercel to route the subdomain to this deployment)

## Test plan

- [ ] Merge and deploy
- [ ] `curl -sI https://uncarved.prometheas.com/anything` returns `301` with `Location: https://prometheas.com/anything`
- [ ] `curl -sI https://prometheas.com/about` returns `200` (main domain unaffected)
- [ ] Closes Phase 2 checklist item from #4: "Add domain: `uncarved.prometheas.com`"
- [ ] Satisfies Phase 4 validation: `https://uncarved.prometheas.com/anything` → 301 → `https://prometheas.com/anything`

Closes part of #4.