### PR TITLE
fix: allow missing file path in pre-write filename hook

### DIFF
--- a/scripts/agent-hooks/pre-write-filename-check.sh
+++ b/scripts/agent-hooks/pre-write-filename-check.sh
@@ -1,25 +1,33 @@
 #!/usr/bin/env bash
-# PreToolUse:Write — block file creation if the name violates kebab-case.
+# PreToolUse:Write — validate filename convention when a concrete file path is present.
 # Source: hook:PreToolUse:Write:filename-convention
 #
-# Called by Claude Code with hook JSON on stdin.
+# Called with hook JSON on stdin.
 # Exit 0 = allow, exit 2 = block.
 
 set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOK_SOURCE="hook:PreToolUse:Write:filename-convention"
 
-FILE_PATH=$(jq -r '.tool_input.file_path' 2>/dev/null) || {
-  echo "[$HOOK_SOURCE] failed to parse tool input JSON" >&2
-  exit 2
-}
+INPUT_JSON="$(cat)"
 
+FILE_PATH="$(
+  printf '%s' "$INPUT_JSON" | jq -r '
+    .tool_input.file_path //
+    .tool_input.filePath //
+    .file_path //
+    .filePath //
+    empty
+  ' 2>/dev/null
+)"
+
+# No concrete file target means this hook is not applicable.
 if [ -z "$FILE_PATH" ] || [ "$FILE_PATH" = "null" ]; then
-  echo "[$HOOK_SOURCE] no file_path found in tool input" >&2
-  exit 2
+  exit 0
 fi
 
-"$SCRIPT_DIR/../check-filename-convention.sh" "$FILE_PATH" 2>&1 || {
-  echo "[$HOOK_SOURCE] blocked — filename violates kebab-case convention" >&2
+if ! "$SCRIPT_DIR/../check-filename-convention.sh" "$FILE_PATH"; then
+  echo "[$HOOK_SOURCE] blocked — filename violates kebab-case convention: $FILE_PATH" >&2
   exit 2
-}
+fi


### PR DESCRIPTION
## Summary
- make the PreToolUse filename-convention hook a no-op when no concrete file path is present
- accept both `file_path` and `filePath` payload shapes before running filename validation
- preserve the existing block behavior for real filename convention violations

## Verification
- `bash -n scripts/agent-hooks/pre-write-filename-check.sh`
- `printf '{"tool_input":{}}' | ./scripts/agent-hooks/pre-write-filename-check.sh` -> exit 0
- `printf '{"tool_input":{"file_path":"src/BadName.tsx"}}' | ./scripts/agent-hooks/pre-write-filename-check.sh` -> exit 2

Closes #15
